### PR TITLE
bcleanall: Return to reasonable branch

### DIFF
--- a/lib/sugarjar/commands.rb
+++ b/lib/sugarjar/commands.rb
@@ -41,6 +41,7 @@ class SugarJar
 
     def bcleanall
       assert_in_repo
+      curr = current_branch
       all_branches.each do |branch|
         next if branch == 'master'
 
@@ -51,6 +52,13 @@ class SugarJar
           )
         end
         # rubocop:enable Style/Next
+      end
+
+      # Return to the branch we were on, or master
+      if all_branches.include?(curr)
+        hub('checkout', 'current')
+      else
+        hub('checkout', 'master')
       end
     end
 


### PR DESCRIPTION
Closes #37

When doing `bcleanall`, we shouldn't land on a random branch. It should
either be where we started, or master.