### PR TITLE
Introducing automatic commit template configuration

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -42,3 +42,6 @@ Style/PercentLiteralDelimiters:
 
 Style/TrailingCommaInArguments:
   EnforcedStyleForMultiline: comma
+
+Metrics/PerceivedComplexity:
+  Enabled: false

--- a/README.md
+++ b/README.md
@@ -246,17 +246,19 @@ troubleshoot configuration parsing.
 ## Repository Configuration
 
 Sugarjar looks for a `.sugarjar.yaml` in the root of the repository to tell it
-how to handle repo-specific things. Currently there are only three
-configurations accepted:
+how to handle repo-specific things. Currently there options are:
 
-* lint - A list of scripts to run on `sj lint`. These should be linters like
+* `lint` - A list of scripts to run on `sj lint`. These should be linters like
   rubocop or pyflake.
-* unit - A list of scripts to run on `sj unit`. These should be unittest
+* `unit` - A list of scripts to run on `sj unit`. These should be unittest
   runners like rspec or pyunit.
-* on_push - A list of types (`lint`, `unit`) of checks to run before pushing.
+* `on_push` - A list of types (`lint`, `unit`) of checks to run before pushing.
   It is highly recommended this is only `lint`. The goal here is to allow for
   the user to get quick stylistic feedback before pushing their branch to avoid
   the push-fix-push-fix loop.
+* `commit_template` - A path to a commit template to set in the `commit.template`
+  git config for this repo. Should be either a fully-qualified path, or a path
+  relative to the repo root.
 
 Example configuration:
 
@@ -267,7 +269,16 @@ unit:
   - scripts/unit
 on_push:
   - lint
+commit_template: .commit-template.txt
 ```
+
+### Commit Templates
+
+While GitHub provides a way to specify a pull-request template by putting the
+right file into a repo, there is no way to tell git to automatically pick up a
+commit template by dropping a file in the repo. Users must do something like:
+`git config commit.template <file>`. Making each developer do this is error
+prone, so this setting will automatically set this up for each developer.
 
 ## Enterprise GitHub
 

--- a/bin/sj
+++ b/bin/sj
@@ -147,7 +147,7 @@ argv_copy = ARGV.dup
 
 # We don't have options yet, but we need an instance of SJ in order
 # to list public methods. We will recreate it
-sj = SugarJar::Commands.new(options)
+sj = SugarJar::Commands.new(options.merge({ 'no_change' => true }))
 extra_opts = []
 
 # as with above, this can't go into 'options', until after we parse
@@ -209,8 +209,8 @@ end
 options = config.merge(options)
 
 # Recreate SJ with all of our options
-sj = SugarJar::Commands.new(options)
 SugarJar::Log.level = options['log_level'].to_sym if options['log_level']
+sj = SugarJar::Commands.new(options)
 
 subcommand = argv_copy.reject { |x| x.start_with?('-') }.first
 argv_copy.delete(subcommand)
@@ -227,7 +227,9 @@ if subcommand == 'help'
 end
 
 if is_valid_command
-  SugarJar::Log.debug("running #{subcommand}, #{extra_opts.join(', ')}")
+  SugarJar::Log.debug(
+    "running #{subcommand}; extra opts: #{extra_opts.join(', ')}",
+  )
   sj.send(subcommand.to_sym, *extra_opts)
 elsif options['fallthru']
   SugarJar::Log.debug("Falling thru to: hub #{ARGV.join(' ')}")


### PR DESCRIPTION
While GitHub provides a way to specify a pull-request template by putting the
right file into a repo, there is no way to tell git to automatically pick up a
commit template by dropping a file in the repo. Users must do something like:
`git config commit.template <file>`. Making each developer do this is error
prone, so this setting will automatically set this up for each developer.

  * Adds `commit_template` to repoconfig option
  * Fixes minor issue where logging level wasn't set as early
    as it should be
  * Sets an option for the "fake" initialization of SugarJar::Commands
    so we don't touch the repo until we're ready

Closes #38