### PR TITLE
Handle git prompts for usernames

### DIFF
--- a/lib/sugarjar/util.rb
+++ b/lib/sugarjar/util.rb
@@ -32,7 +32,8 @@ class SugarJar
       if s.error?
         # depending on hub version and possibly other things, STDERR
         # is either "Requires authentication" or "Must authenticate"
-        if s.stderr =~ /^(Must|Requires) authenticat/
+        case s.stderr
+        when /^(Must|Requires) authenticat/
           SugarJar::Log.info(
             'Hub was run but no github token exists. Will run "hub api user" ' +
             "to force\nhub to authenticate...",
@@ -47,7 +48,7 @@ class SugarJar
           end
           SugarJar::Log.info('Re-running original hub command...')
           s = Mixlib::ShellOut.new([which('hub')] + args).run_command
-        elsif s.stderr =~ /^fatal: could not read Username/
+        when /^fatal: could not read Username/
           # On http(s) URLs, git may prompt for username/passwd
           SugarJar::Log.info(
             'Hub was run but git prompted for authentication. This probably ' +
@@ -55,7 +56,7 @@ class SugarJar
             "is recommended you reclone\nusing 'sj sclone' to setup your " +
             "remotes properly. However, in the meantime,\nwe'll go ahead " +
             "and re-run the command in a shell so you can type in the\n" +
-            'credentials.'
+            'credentials.',
           )
           unless system(which('hub'), *args)
             SugarJar::Log.fatal(

--- a/lib/sugarjar/util.rb
+++ b/lib/sugarjar/util.rb
@@ -29,23 +29,45 @@ class SugarJar
     def hub_nofail(*args)
       SugarJar::Log.trace("Running: hub #{args.join(' ')}")
       s = Mixlib::ShellOut.new([which('hub')] + args).run_command
-      # depending on hub version and possibly other things, STDERR
-      # is either "Requires authentication" or "Must authenticate"
-      if s.error? && s.stderr =~ /^(Must|Requires) authenticat/
-        SugarJar::Log.info(
-          'Hub was run but no github token exists. Will run "hub api user" ' +
-          "to force\nhub to authenticate...",
-        )
-        unless system(which('hub'), 'api', 'user')
-          SugarJar::Log.fatal(
-            'That failed, I will bail out. Hub needs to get a github ' +
-            'token. Try running "hub api user" (will list info about ' +
-            'your account) and try this again when that works.',
+      if s.error?
+        # depending on hub version and possibly other things, STDERR
+        # is either "Requires authentication" or "Must authenticate"
+        if s.stderr =~ /^(Must|Requires) authenticat/
+          SugarJar::Log.info(
+            'Hub was run but no github token exists. Will run "hub api user" ' +
+            "to force\nhub to authenticate...",
           )
-          exit(1)
+          unless system(which('hub'), 'api', 'user')
+            SugarJar::Log.fatal(
+              'That failed, I will bail out. Hub needs to get a github ' +
+              'token. Try running "hub api user" (will list info about ' +
+              'your account) and try this again when that works.',
+            )
+            exit(1)
+          end
+          SugarJar::Log.info('Re-running original hub command...')
+          s = Mixlib::ShellOut.new([which('hub')] + args).run_command
+        elsif s.stderr =~ /^fatal: could not read Username/
+          # On http(s) URLs, git may prompt for username/passwd
+          SugarJar::Log.info(
+            'Hub was run but git prompted for authentication. This probably ' +
+            "means you have\nused an http repo URL instead of an ssh one. It " +
+            "is recommended you reclone\nusing 'sj sclone' to setup your " +
+            "remotes properly. However, in the meantime,\nwe'll go ahead " +
+            "and re-run the command in a shell so you can type in the\n" +
+            'credentials.'
+          )
+          unless system(which('hub'), *args)
+            SugarJar::Log.fatal(
+              'That failed, I will bail out. You can either manually change ' +
+              'your remotes, or simply create a fresh clone with ' +
+              '"sj smartclone".',
+            )
+            exit(1)
+          end
+          SugarJar::Log.info('Re-running original hub command...')
+          s = Mixlib::ShellOut.new([which('hub')] + args).run_command
         end
-        SugarJar::Log.info('Re-running original hub command...')
-        s = Mixlib::ShellOut.new([which('hub')] + args).run_command
       end
       s
     end


### PR DESCRIPTION
When using http(s) remotes git can prompt, and we need to handle that
appropriately.

Closes #52