### PR TITLE
Add smartpr; add dirty checks in {s,f}push

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,6 +7,9 @@ AllCops:
 Layout/LineLength:
   Max: 80
 
+Metrics/CyclomaticComplexity:
+  Enabled: false
+
 Metrics/AbcSize:
   Enabled: false
 

--- a/bin/sj
+++ b/bin/sj
@@ -61,6 +61,20 @@ parser = OptionParser.new do |opts|
     options['log_level'] = level
   end
 
+  opts.on(
+    '--ignore-dirty',
+    'Tell command that check for a dirty repo to carry on anyway.',
+  ) do
+    options['ignore_dirty'] = true
+  end
+
+  opts.on(
+    '--ignore-prerun-failure',
+    'Ignore preprun failure on *push commands.',
+  ) do
+    options['ignore_prerun_failure'] = true
+  end
+
   opts.on('--version') do
     puts SugarJar::VERSION
     exit
@@ -118,6 +132,10 @@ COMMANDS:
               as your github-user then it will fork the repo for you to
               your account (if not already done) and then setup your remotes
               so that "origin" is your fork and "upstream" is the upstream.
+
+  smartpullrequest, smartpr, spr
+              A smart wrapper to "hub pull-request" that checks if your repo
+              is dirty before creating the pull request.
 
   smartpush, spush
               A smart wrapper to "git push" that runs whatever is defined in


### PR DESCRIPTION
Add a new `smartpullrequest` command (aliases: `spr` and `smartpr`).
It's a shortcut for `hub pull-request`, but checks for a dirty repo
first.

That closes #51

Since we have a dirty check now, this adds it to `smartpush` and
`forcepush` as well as refactors those to DRY them up a bit.

Finally, this adds `--ignore-dirty` and `--ignore-prerun-failure` to
allow bypassing botht he new dirty check and the existing prerun checks.