### PR TITLE
Better support for autocorrecting linters

### DIFF
--- a/.sugarjar.yaml
+++ b/.sugarjar.yaml
@@ -1,6 +1,6 @@
 on_push: [lint]
 lint:
-  - scripts/run_rubocop.sh -D
+  - scripts/run_rubocop.sh -D -a
   - scripts/run_mdl.sh -g .
 unit:
   - scripts/unit


### PR DESCRIPTION
For each linter, if the repo becomes dirty, prompt the user to amend
or quit.

This solves the problem where today users can be confused if a linter
fixes something but errors and the user doesn't get a clear
understanding, or when it changes something, but doesn't error and
what we push isn't in the repo.

Output looks like this:

```shell
[phil@rider (betterlint) RVM(2.7.1) sugarjar]$ ./bin/sj lint
[lint] scripts/run_rubocop.sh: Corrected
WARN: The linter modified the repo. Here's the diff:

diff --git a/lib/sugarjar/commands.rb b/lib/sugarjar/commands.rb
index d350b54..d9c9491 100644
--- a/lib/sugarjar/commands.rb
+++ b/lib/sugarjar/commands.rb
@@ -405,7 +405,7 @@ class SugarJar
                 SugarJar::Log.info('Exiting at user request.')
                 exit(1)
               when /^a/
-                qamend("-a")
+                qamend('-a')
                 # break here, if we get out of this loop we 'redo', assuming
                 # the user chose this option
                 break

Would you like to
	[q]uit and inspect
	[a]mend the changes to the current commit and re-run
  > a
[betterlint f2dfabf] Better lint
 Date: Sat Feb 20 14:29:34 2021 -0800
 2 files changed, 39 insertions(+), 10 deletions(-)

[lint] scripts/run_rubocop.sh: OK
[lint] scripts/run_mdl.sh: OK
[phil@rider (betterlint) RVM(2.7.1) sugarjar]$
```