### PR TITLE
Various fixes to releasing

### DIFF
--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -23,9 +23,10 @@
 * Inside of each VM...
 
   ```shell
-  for d in ubuntu-1804 debian-10 centos-7; do
+  for d in ubuntu-1804 ubuntu-2004 debian-10 centos-7 centos-8; do
     bundle exec kitchen converge default-$d && \
-      bundle exec kitchen login default-$d
+      bundle exec kitchen login default-$d && \
+      bundle exec kitchen destroy default-$d
   done
   ```
 
@@ -36,8 +37,8 @@
     [ -e .bundle ] && sudo chown -R vagrant:vagrant .bundle
     cd sugarjar/omnibus
     bundle install
-    bin/omnibus build sugarjar
-    bin/omnibus clean sugarjar # required so next build works
+    bin/omnibus build sugarjar && \
+      bin/omnibus clean sugarjar # required so next build works
     ```
 
   * Grab/rename the package out of sugarjar/omnibus/pkg

--- a/omnibus/.kitchen.yml
+++ b/omnibus/.kitchen.yml
@@ -11,9 +11,9 @@ provisioner:
   name: chef_zero
 
 platforms:
-  - name: centos-6
-    run_list: yum-epel::default
   - name: centos-7
+    run_list: yum-epel::default
+  - name: centos-8
     run_list: yum-epel::default
   - name: debian-8
     run_list: apt::default
@@ -25,11 +25,11 @@ platforms:
     run_list: freebsd::portsnap
   - name: freebsd-11
     run_list: freebsd::portsnap
-  - name: ubuntu-14.04
-    run_list: apt::default
   - name: ubuntu-16.04
     run_list: apt::default
   - name: ubuntu-18.04
+    run_list: apt::default
+  - name: ubuntu-20.04
     run_list: apt::default
 
 suites:

--- a/omnibus/config/projects/sugarjar.rb
+++ b/omnibus/config/projects/sugarjar.rb
@@ -19,7 +19,7 @@ install_dir "#{default_root}/#{name}"
 build_version SugarJar::VERSION
 build_iteration 1
 
-override 'ruby', :version => '2.7.2'
+override 'ruby', :version => '2.7.1'
 
 dependency 'preparation'
 dependency 'sugarjar'


### PR DESCRIPTION
* move back to ruby 2.7.1 - only thing that seems to build on centos
* add centos 8 and ubuntu 20.04 to releases we build
* update release instructions to auto-cleanup kitchen instances