### PR TITLE
Handle 'version' better when using `gh`

### DIFF
--- a/lib/sugarjar/commands.rb
+++ b/lib/sugarjar/commands.rb
@@ -265,6 +265,9 @@ class SugarJar
     def version
       puts "sugarjar version #{SugarJar::VERSION}"
       puts ghcli('version').stdout
+      # 'hub' prints the 'git' version, but gh doesn't, so if we're on 'gh'
+      # print out the git version directly
+      puts git('version').stdout if gh?
     end
 
     def smartpullrequest(*args)


### PR DESCRIPTION
Signed-off-by: Phil Dibowitz <phil@ipom.com>
