### PR TITLE
Prep version 0.0.11

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.6, 2.7]
+        # don't really need to do linting on multiple versions of ruby
+        ruby: [3.1.1]
     runs-on: ubuntu-latest
     steps:
     - name: checkout

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.6, 2.7]
+        ruby: [2.6, 2.7, 3.1.1]
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # SugarJar Changelog
 
+## 0.0.11 (2022-10-06)
+
+* Properly handle slashes in branch names (closes #101)
+* Support for running a command to determine checks (linters, units) to run
+* Support for using `gh` CLI instead of `hub` (experimental)
+* Add new `pullsuggestions` command to pull in (accepted) suggestions from a
+  GitHub code review.
+* Detect mismatched primary branch names to assist with projects changing from
+  `master` to `main`
+
 ## 0.0.10 (2021-12-06)
 
 * Support 'main' as a default/primary branch

--- a/lib/sugarjar/version.rb
+++ b/lib/sugarjar/version.rb
@@ -1,3 +1,3 @@
 class SugarJar
-  VERSION = '0.0.10'.freeze
+  VERSION = '0.0.11'.freeze
 end


### PR DESCRIPTION
changelog, version info, etc.

Plus cleanup versions of ruby that lint/unit run on.