### PR TITLE
Allow commands_spec to be run against the installed copy of sugarjar

### DIFF
--- a/spec/commands_spec.rb
+++ b/spec/commands_spec.rb
@@ -1,5 +1,15 @@
 # require 'spec_helper'
-require_relative '../lib/sugarjar/commands'
+# For Ruby packages, Debian autopkgtest runs in an environment where
+# gem2deb-test-runner removes the lib directory from the source tree, so
+# the specs have to be able to load the installed copy instead.
+#
+# add '../lib' to the front of the path, so that when requiring modules, the
+# ones in '../lib' are still going to be used if available, but we can fall
+# back to an installed module
+#
+# See https://wiki.debian.org/Teams/Ruby/Packaging/Tests#Case_eight:_autopkgtest_failure
+$LOAD_PATH.unshift File.expand_path('lib', __dir__)
+require 'sugarjar/commands'
 
 describe 'SugarJar::Commands' do
   context '#set_commit_template' do


### PR DESCRIPTION
For Ruby packages, Debian autopkgtest runs in an environment where `gem2deb-test-runner` removes the `lib` directory from the source tree, so the specs have to be able to load the installed copy instead.

With this change, `lib` gets added to the front of the path, and the relative `require` is changed to not specify a path. So when specs are run from a source tree checkout the `lib` in the checkout is still preferred, but if it's not available the installed library gets used to satisfy the `require`.

See https://wiki.debian.org/Teams/Ruby/Packaging/Tests#Case_eight:_autopkgtest_failure

Signed-off-by: Michel Alexandre Salim <michel@michel-slm.name>