### PR TITLE
New feature: feature prefixes

### DIFF
--- a/bin/sj
+++ b/bin/sj
@@ -33,6 +33,10 @@ parser = OptionParser.new do |opts|
     options['fallthru'] = fallthru
   end
 
+  opts.on('--feature-prefix', 'Prefix to use for feature branches') do |prefix|
+    options['feature_prefix'] = prefix
+  end
+
   opts.on(
     '--github-cli CLI',
     %w{gh cli},
@@ -128,6 +132,12 @@ COMMANDS:
               some form of 'master' instead of your current branch. In order
               of preference it will be upstream/master, origin/master, master,
               depending upon what remotes are available.
+
+              Note that you can specify "--feature-prefix" (or add
+              "feature_prefix" to your config) to have all features created
+              with a prefix. This is useful for branch-based workflows where
+              developers are expected to create branches names that, for
+              example, start with their username.
 
   forcepush, fpush
               The same as "smartpush", but uses "--force-with-lease". This is

--- a/spec/commands_spec.rb
+++ b/spec/commands_spec.rb
@@ -161,4 +161,18 @@ describe 'SugarJar::Commands' do
         to eq('git@github.com:org/repo.git')
     end
   end
+
+  context '#fprefix' do
+    it 'Adds prefixes when needed' do
+      sj = SugarJar::Commands.new(
+        { 'no_change' => true, 'feature_prefix' => 'someuser/' },
+      )
+      expect(sj.send(:fprefix, 'test')).to eq('someuser/test')
+    end
+
+    it 'Does not add prefixes when not needed' do
+      sj = SugarJar::Commands.new({ 'no_change' => true })
+      expect(sj.send(:fprefix, 'test')).to eq('test')
+    end
+  end
 end


### PR DESCRIPTION
This adds a new feature, feature prefixes, which will create all
features with a prefix, which is useful in branch-based workflows
where developers are expected to create all branches with a specific
prefix like "$USER/".

Signed-off-by: Phil Dibowitz <phil@ipom.com>
