### PR TITLE
featureprefix, linter, smartpr fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,14 @@ $ sj feature dependent-feature test-branch
 Created feature branch dependent-feature based on test-branch
 ```
 
+Additionally you can specify a `feature_prefix` in your config which will cause
+`feature` to create branches prefixed with your `feature_prefix` and will also
+cause `co` to checkout branches with that prefix. This is useful when organizations
+use branch-based workflows and branches need to be prefixed with e.g. `$USER/`.
+
+For example, if your prefix was `user/`, then `sj feature foo` would create
+`user/foo`, and `sj co foo` would switch to `user/foo`.
+
 ## Smartlog
 
 Smartlog will show you a tree diagram of your branches! Simply run `sj
@@ -319,6 +327,12 @@ how to handle repo-specific things. Currently there options are:
 * `commit_template` - A path to a commit template to set in the `commit.template`
   git config for this repo. Should be either a fully-qualified path, or a path
   relative to the repo root.
+* `include_from` - This will read an additional repoconfig file and merge it
+  into the one being read. The value should be relative to the root of the
+  repo. This will not error if the file does not exist, it is intended for
+  organizations to allow users to optionally extend a default repo config.
+* `overwrite_from` - Same as `include_from`, but completely overwrites the
+  base configuration if the file is found.
 
 Example configuration:
 

--- a/spec/repoconfig_spec.rb
+++ b/spec/repoconfig_spec.rb
@@ -1,0 +1,141 @@
+$LOAD_PATH.unshift File.expand_path('lib', __dir__)
+require 'sugarjar/repoconfig'
+
+describe 'SugarJar::RepoConfig' do
+  context '#config' do
+    it 'properly reads config' do
+      expected = {
+        'lint' => [
+          'somecommand',
+          'another command',
+        ],
+        'unit' => [
+          'test',
+        ],
+        'on_push' => [
+          'lint',
+        ],
+      }
+      allow(SugarJar::RepoConfig).to receive(:hash_from_file).
+        and_return(expected)
+      data = SugarJar::RepoConfig.config('whatever')
+      # we gave it expected, this test basically makes sure we don't
+      # break the data along the way
+      expect(data).to eq(expected)
+    end
+
+    it 'merges include_from into config' do
+      base = {
+        'include_from' => 'additional',
+        'top1' => ['entryA'],
+        'top2' => {
+          'top2key1' => 'a',
+          'top2key2' => 'b',
+        },
+      }
+      additional = {
+        # array merge
+        'top1' => ['entryB'],
+        'top2' => {
+          # key overwrite
+          'top2key1' => 'new',
+          # additional key
+          'top2key3' => 'c',
+        },
+      }
+      expected = {
+        'top1' => %w{entryA entryB},
+        'top2' => {
+          'top2key1' => 'new',
+          'top2key2' => 'b',
+          'top2key3' => 'c',
+        },
+      }
+      allow(SugarJar::RepoConfig).to receive(:repo_config_path).
+        with('base').and_return('base')
+      allow(SugarJar::RepoConfig).to receive(:repo_config_path).
+        with('additional').and_return('additional')
+      allow(SugarJar::RepoConfig).to receive(:hash_from_file).
+        with('base').and_return(base)
+      allow(SugarJar::RepoConfig).to receive(:hash_from_file).
+        with('additional').and_return(additional)
+      data = SugarJar::RepoConfig.config('base')
+      expect(data).to eq(expected)
+    end
+
+    it 'overwrites config with overwrite_from' do
+      base = {
+        'overwrite_from' => 'additional',
+        'top1' => ['entryA'],
+        'top2' => {
+          'top2key1' => 'a',
+          'top2key2' => 'b',
+        },
+      }
+      additional = {
+        'new' => ['thing'],
+      }
+      allow(SugarJar::RepoConfig).to receive(:repo_config_path).
+        with('base').and_return('base')
+      allow(SugarJar::RepoConfig).to receive(:repo_config_path).
+        with('additional').and_return('additional')
+      allow(SugarJar::RepoConfig).to receive(:hash_from_file).
+        with('base').and_return(base)
+      allow(SugarJar::RepoConfig).to receive(:hash_from_file).
+        with('additional').and_return(additional)
+      data = SugarJar::RepoConfig.config('base')
+      # it doesn't matter what's in 'base', we should get 'additional' back
+      expect(data).to eq(additional)
+    end
+
+    it 'handles recurseive includes' do
+      base = {
+        'include_from' => 'additional',
+        'top1' => ['entryA'],
+        'top2' => {
+          'top2key1' => 'a',
+          'top2key2' => 'b',
+        },
+      }
+      additional = {
+        # array merge
+        'include_from' => 'more',
+        'top1' => ['entryB'],
+        'top2' => {
+          # key overwrite
+          'top2key1' => 'new',
+          # additional key
+          'top2key3' => 'c',
+        },
+      }
+      more = {
+        'other stuff' => {
+          'things' => 'stuff',
+        },
+      }
+      expected = {
+        'top1' => %w{entryA entryB},
+        'top2' => {
+          'top2key1' => 'new',
+          'top2key2' => 'b',
+          'top2key3' => 'c',
+        },
+        'other stuff' => {
+          'things' => 'stuff',
+        },
+      }
+      %w{base additional more}.each do |word|
+        allow(SugarJar::RepoConfig).to receive(:repo_config_path).
+          with(word).and_return(word)
+      end
+      allow(SugarJar::RepoConfig).to receive(:hash_from_file).
+        with('base').and_return(base)
+      allow(SugarJar::RepoConfig).to receive(:hash_from_file).
+        with('additional').and_return(additional)
+      allow(SugarJar::RepoConfig).to receive(:hash_from_file).
+        with('more').and_return(more)
+      data = SugarJar::RepoConfig.config('base')
+      expect(data).to eq(expected)
+    end
+  end
+end

--- a/sugarjar.gemspec
+++ b/sugarjar.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |spec|
     Dir.glob('bin/*') +
     docs
 
+  spec.add_dependency 'deep_merge'
   spec.add_dependency 'mixlib-log'
   spec.add_dependency 'mixlib-shellout'
   spec.add_dependency 'pastel'


### PR DESCRIPTION
* Add support for `include_from` and `overwrite_from` in
  repoconfig
* Add support for featureprefix to `co`
* Allow relative paths for linters and unittests
* Smartpr now uses `--fill` when utilizing `gh`

Signed-off-by: Phil Dibowitz <phil@ipom.com>
