### PR TITLE
Fix the LOAD_PATH dirs for the specs

### DIFF
--- a/spec/commands_spec.rb
+++ b/spec/commands_spec.rb
@@ -1,4 +1,3 @@
-# require 'spec_helper'
 # For Ruby packages, Debian autopkgtest runs in an environment where
 # gem2deb-test-runner removes the lib directory from the source tree, so
 # the specs have to be able to load the installed copy instead.
@@ -8,7 +7,7 @@
 # back to an installed module
 #
 # See https://wiki.debian.org/Teams/Ruby/Packaging/Tests#Case_eight:_autopkgtest_failure
-$LOAD_PATH.unshift File.expand_path('lib', __dir__)
+$LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 require 'sugarjar/commands'
 
 describe 'SugarJar::Commands' do

--- a/spec/repoconfig_spec.rb
+++ b/spec/repoconfig_spec.rb
@@ -1,4 +1,4 @@
-$LOAD_PATH.unshift File.expand_path('lib', __dir__)
+$LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 require 'sugarjar/repoconfig'
 
 describe 'SugarJar::RepoConfig' do


### PR DESCRIPTION
These should always have been `../lib`.

Signed-off-by: Phil Dibowitz <phil@ipom.com>
