### PR TITLE
Minor cleanups

### DIFF
--- a/lib/sugarjar/util.rb
+++ b/lib/sugarjar/util.rb
@@ -1,5 +1,7 @@
 require_relative 'log'
 
+require 'mixlib/shellout'
+
 class SugarJar
   # Some common methods needed by other classes
   module Util

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -33,7 +33,7 @@ the old ones. First follow the directions in the spec file to build the tarball
 for the test files. Then wget the gem from the URL in the spec file. Then:
 
 ```shell
-fedpkg new-sources rubygem-sugarjar-<version>-specs.tar.gz sugarjar-<version>.gem
+fedpkg new-sources rubygem-sugarjar-<version>-specs.tar sugarjar-<version>.gem
 ```
 
 ## Testing


### PR DESCRIPTION
* Add missing `require` to `util.rb` - this works fine today in
  the app, but only because the main code already includes
  `mixlib/shellout`
* Update release instructions for Fedora

Signed-off-by: Phil Dibowitz <phil@ipom.com>
