### PR TITLE
Relax ruby requirements

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,17 +12,14 @@ jobs:
   rubocop:
     strategy:
       fail-fast: false
-      matrix:
-        # don't really need to do linting on multiple versions of ruby
-        ruby: [3.1.1]
     runs-on: ubuntu-latest
     steps:
     - name: checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Setup ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: ${{ matrix.ruby }}
+        ruby-version: '3.2'
     - name: install deps
       run: bundle install
     - name: Run rubocop
@@ -40,6 +37,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: MarkdownLint mdl Action
         uses: actionshub/markdownlint@1.2.0

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -11,11 +11,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [3.0, 3.1, 3.2]
+        ruby: [3.0, 3.1, 3.2, 3.3]
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Setup Ruby
       uses: ruby/setup-ruby@v1
       with:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 3.1
+  TargetRubyVersion: 3.0
   NewCops: enable
   Exclude:
     - 'omnibus/bin/**/*'

--- a/sugarjar.gemspec
+++ b/sugarjar.gemspec
@@ -8,7 +8,9 @@ Gem::Specification.new do |spec|
   spec.email = ['phil@ipom.com']
   spec.license = 'Apache-2.0'
   spec.homepage = 'https://github.com/jaymzh/sugarjar'
-  spec.required_ruby_version = '>= 3.1'
+  # We'll support 3.0 until 2024-03-31 when it goes EOL
+  # https://www.ruby-lang.org/en/downloads/branches/
+  spec.required_ruby_version = '>= 3.0'
   docs = %w{README.md LICENSE Gemfile sugarjar.gemspec}
   spec.extra_rdoc_files = docs
   spec.executables << 'sj'


### PR DESCRIPTION
When I did ruby cleanups I dropped everything that wasn't in "normal
maintenance", but that causes issues for some Distros that lag behind
on their ruby updates. So we'll allow up through security maintenance,
which means adding back 3.0.

Also, start testing on 3.3.
