### PR TITLE
Fix aborted rebases

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,6 +76,7 @@ GEM
     unicode-display_width (2.5.0)
 
 PLATFORMS
+  x86_64-darwin-23
   x86_64-linux
 
 DEPENDENCIES


### PR DESCRIPTION
Sometimes `git` will detect a rebase will fail and will abort it
for us. If this happens, when we try to abort, it'll fail. Detect
this case and don't abort if `git` already did.
