### PR TITLE
SPR: don't autofill when more than one commit exists

### DIFF
--- a/bin/sj
+++ b/bin/sj
@@ -91,6 +91,14 @@ parser = OptionParser.new do |opts|
     options['log_level'] = level
   end
 
+  opts.on(
+    '--[no-]pr-autofill',
+    'When creating a PR, auto fill the title & description from the commit ' +
+    'if there is a single commit and if we are using "gh". [default: true]',
+  ) do |autofill|
+    options['pr_autofill'] = autofill
+  end
+
   opts.on('--[no-]use-color', 'Enable color. [default: true]') do |color|
     options['color'] = color
   end

--- a/lib/sugarjar/config.rb
+++ b/lib/sugarjar/config.rb
@@ -9,6 +9,7 @@ class SugarJar
       'github_cli' => 'auto',
       'github_user' => ENV.fetch('USER'),
       'fallthru' => true,
+      'pr_autofill' => true,
     }.freeze
 
     def self._find_ordered_files


### PR DESCRIPTION
* If > 1 commit exists, don't pass in --fill
* Add a new option to allow people to opt-out of --fill in all cases
* Tell people when we are autofilling

Closes #152

Signed-off-by: Phil Dibowitz <phil@ipom.com>
