### PR TITLE
sj-feature: set tracked branch

### DIFF
--- a/lib/sugarjar/commands.rb
+++ b/lib/sugarjar/commands.rb
@@ -50,6 +50,7 @@ class SugarJar
         git('fetch', base_pieces[0]) if base_pieces.length > 1
       end
       git('checkout', '-b', name, base)
+      git('branch', '-u', base)
       SugarJar::Log.info(
         "Created feature branch #{color(name, :green)} based on " +
         color(base, :green),


### PR DESCRIPTION
Make sure to set the tracked branch when creating features
so that `sj up` works as expected.
