### PR TITLE
Cleanup stacked PR handling

### DIFF
--- a/bin/sj
+++ b/bin/sj
@@ -93,8 +93,8 @@ parser = OptionParser.new do |opts|
 
   opts.on(
     '--[no-]pr-autofill',
-    'When creating a PR, auto fill the title & description from the commit ' +
-    'if there is a single commit and if we are using "gh". [default: true]',
+    'When creating a PR, auto fill the title & description from the top ' +
+    'commit if we are using "gh". [default: true]',
   ) do |autofill|
     options['pr_autofill'] = autofill
   end
@@ -104,7 +104,7 @@ parser = OptionParser.new do |opts|
     'When creating a PR, if this is a subfeature, should we make it a ' +
     'PR on the PR for the parent feature. If not specified, we prompt ' +
     'when this happens, when true always do this, when false never do ' +
-    'this. Only applicable when usiing "gh".',
+    'this. Only applicable when usiing "gh" and on branch-based PRs.',
   ) do |autostack|
     options['pr_autostack'] = autostack
   end

--- a/lib/sugarjar/commands.rb
+++ b/lib/sugarjar/commands.rb
@@ -334,21 +334,27 @@ class SugarJar
         curr = current_branch
         base = tracked_branch
         if @pr_autofill
+          SugarJar::Log.info('Autofilling in PR from commit message')
           num_commits = git(
             'rev-list', '--count', curr, "^#{base}"
           ).stdout.strip.to_i
           if num_commits > 1
-            SugarJar::Log.debug(
-              "Not using --fill because there are #{num_commits} commits",
-            )
+            args.unshift('--fill-first')
           else
-            SugarJar::Log.info('Autofilling in PR from commit message')
             args.unshift('--fill')
           end
         end
         if subfeature?(base)
+          if upstream != push_org
+            SugarJar::Log.warn(
+              'Unfortunately you cannot based one PR on another PR when' +
+              " using fork-based PRs. We will base this on #{most_main}." +
+              ' This just means the PR "Changes" tab will show changes for' +
+              ' the full stack until those other PRs are merged and this PR' +
+              ' PR is rebased.',
+            )
           # nil is prompt, true is always, false is never
-          if @pr_autostack.nil?
+          elsif @pr_autostack.nil?
             $stdout.print(
               'It looks like this is a subfeature, would you like to base ' +
               "this PR on #{base}? [y/n] ",


### PR DESCRIPTION
* If on a forked repo, note that we cannot stack PRs
* Use `--fill-first` when needed
