### PR TITLE
Fix subfeature PR creation; plus some cleanups

### DIFF
--- a/lib/sugarjar/commands/amend.rb
+++ b/lib/sugarjar/commands/amend.rb
@@ -1,13 +1,13 @@
 class SugarJar
   class Commands
     def amend(*args)
-      assert_in_repo
+      assert_in_repo!
       # This cannot use shellout since we need a full terminal for the editor
       exit(system(which('git'), 'commit', '--amend', *args))
     end
 
     def qamend(*args)
-      assert_in_repo
+      assert_in_repo!
       SugarJar::Log.info(git('commit', '--amend', '--no-edit', *args).stdout)
     end
     alias amendq qamend

--- a/lib/sugarjar/commands/bclean.rb
+++ b/lib/sugarjar/commands/bclean.rb
@@ -1,7 +1,7 @@
 class SugarJar
   class Commands
     def bclean(name = nil)
-      assert_in_repo
+      assert_in_repo!
       name ||= current_branch
       name = fprefix(name)
       if clean_branch(name)
@@ -15,7 +15,7 @@ class SugarJar
     end
 
     def bcleanall
-      assert_in_repo
+      assert_in_repo!
       curr = current_branch
       all_local_branches.each do |branch|
         if MAIN_BRANCHES.include?(branch)

--- a/lib/sugarjar/commands/branch.rb
+++ b/lib/sugarjar/commands/branch.rb
@@ -1,7 +1,7 @@
 class SugarJar
   class Commands
     def checkout(*args)
-      assert_in_repo
+      assert_in_repo!
       # Pop the last arguement, which is _probably_ a branch name
       # and then add any featureprefix, and if _that_ is a branch
       # name, replace the last arguement with that
@@ -17,12 +17,12 @@ class SugarJar
     alias co checkout
 
     def br
-      assert_in_repo
+      assert_in_repo!
       SugarJar::Log.info(git('branch', '-v').stdout.chomp)
     end
 
     def binfo
-      assert_in_repo
+      assert_in_repo!
       SugarJar::Log.info(git(
         'log', '--graph', '--oneline', '--decorate', '--boundary',
         "#{tracked_branch}.."
@@ -31,7 +31,7 @@ class SugarJar
 
     # binfo for all branches
     def smartlog
-      assert_in_repo
+      assert_in_repo!
       SugarJar::Log.info(git(
         'log', '--graph', '--oneline', '--decorate', '--boundary',
         '--branches', "#{most_main}.."

--- a/lib/sugarjar/commands/checks.rb
+++ b/lib/sugarjar/commands/checks.rb
@@ -1,12 +1,12 @@
 class SugarJar
   class Commands
     def lint
-      assert_in_repo
+      assert_in_repo!
       exit(1) unless run_check('lint')
     end
 
     def unit
-      assert_in_repo
+      assert_in_repo!
       exit(1) unless run_check('unit')
     end
 

--- a/lib/sugarjar/commands/feature.rb
+++ b/lib/sugarjar/commands/feature.rb
@@ -1,7 +1,7 @@
 class SugarJar
   class Commands
     def feature(name, base = nil)
-      assert_in_repo
+      assert_in_repo!
       SugarJar::Log.debug("Feature: #{name}, #{base}")
       name = fprefix(name)
       die("#{name} already exists!") if all_local_branches.include?(name)
@@ -21,7 +21,7 @@ class SugarJar
     alias f feature
 
     def subfeature(name)
-      assert_in_repo
+      assert_in_repo!
       SugarJar::Log.debug("Subfature: #{name}")
       feature(name, current_branch)
     end

--- a/lib/sugarjar/commands/pullsuggestions.rb
+++ b/lib/sugarjar/commands/pullsuggestions.rb
@@ -1,7 +1,7 @@
 class SugarJar
   class Commands
     def pullsuggestions
-      assert_in_repo
+      assert_in_repo!
 
       if dirty?
         if @ignore_dirty

--- a/lib/sugarjar/commands/push.rb
+++ b/lib/sugarjar/commands/push.rb
@@ -1,13 +1,13 @@
 class SugarJar
   class Commands
     def smartpush(remote = nil, branch = nil)
-      assert_in_repo
+      assert_in_repo!
       _smartpush(remote, branch, false)
     end
     alias spush smartpush
 
     def forcepush(remote = nil, branch = nil)
-      assert_in_repo
+      assert_in_repo!
       _smartpush(remote, branch, true)
     end
     alias fpush forcepush

--- a/lib/sugarjar/commands/smartpullrequest.rb
+++ b/lib/sugarjar/commands/smartpullrequest.rb
@@ -1,8 +1,8 @@
 class SugarJar
   class Commands
     def smartpullrequest(*args)
-      assert_in_repo
-      assert_common_main_branch
+      assert_in_repo!
+      assert_common_main_branch!
 
       if dirty?
         SugarJar::Log.warn(
@@ -26,7 +26,7 @@ class SugarJar
         end
       end
       if subfeature?(base)
-        if upstream != push_org
+        if upstream_org != push_org
           SugarJar::Log.warn(
             'Unfortunately you cannot based one PR on another PR when' +
             " using fork-based PRs. We will base this on #{most_main}." +

--- a/lib/sugarjar/commands/up.rb
+++ b/lib/sugarjar/commands/up.rb
@@ -1,7 +1,7 @@
 class SugarJar
   class Commands
     def up(branch = nil)
-      assert_in_repo
+      assert_in_repo!
       branch ||= current_branch
       branch = fprefix(branch)
       # get a copy of our current branch, if rebase fails, we won't
@@ -32,7 +32,7 @@ class SugarJar
     end
 
     def upall
-      assert_in_repo
+      assert_in_repo!
       all_local_branches.each do |branch|
         next if MAIN_BRANCHES.include?(branch)
 

--- a/lib/sugarjar/repoconfig.rb
+++ b/lib/sugarjar/repoconfig.rb
@@ -27,7 +27,7 @@ class SugarJar
 
     def self.config(config = CONFIG_NAME)
       data = {}
-      unless in_repo
+      unless in_repo?
         SugarJar::Log.debug('Not in repo, skipping repoconfig load')
         return data
       end

--- a/lib/sugarjar/util.rb
+++ b/lib/sugarjar/util.rb
@@ -42,7 +42,7 @@ class SugarJar
     end
 
     def set_commit_template
-      unless in_repo
+      unless in_repo?
         SugarJar::Log.debug('Skipping set_commit_template: not in repo')
         return
       end
@@ -98,7 +98,7 @@ class SugarJar
       exit(1)
     end
 
-    def assert_common_main_branch
+    def assert_common_main_branch!
       upstream_branch = main_remote_branch(upstream)
       unless main_branch == upstream_branch
         die(
@@ -126,8 +126,8 @@ class SugarJar
       )
     end
 
-    def assert_in_repo
-      die('sugarjar must be run from inside a git repo') unless in_repo
+    def assert_in_repo!
+      die('sugarjar must be run from inside a git repo') unless in_repo?
     end
 
     def determine_main_branch(branches)
@@ -169,6 +169,15 @@ class SugarJar
 
     def all_remotes
       git('remote').stdout.lines.map(&:strip)
+    end
+
+    def remote_url_map
+      m = {}
+      git('remote', '-v').stdout.each_line do |line|
+        name, url, = line.split
+        m[name] = url
+      end
+      m
     end
 
     def current_branch
@@ -234,6 +243,12 @@ class SugarJar
         raise 'Could not determine "upstream" remote to use...'
       end
       @remote
+    end
+
+    def upstream_org
+      us = upstream
+      remotes = remote_url_map
+      extract_org(remotes[us])
     end
 
     # Whatever org we push to, regardless of if this is a fork or not
@@ -353,7 +368,7 @@ class SugarJar
       s
     end
 
-    def in_repo
+    def in_repo?
       s = git_nofail('rev-parse', '--is-inside-work-tree')
       !s.error? && s.stdout.strip == 'true'
     end

--- a/spec/commands_spec.rb
+++ b/spec/commands_spec.rb
@@ -17,7 +17,7 @@ describe 'SugarJar::Commands' do
         { 'commit_template' => '.commit_template.txt' },
       )
       sj = SugarJar::Commands.new({ 'no_change' => true })
-      expect(sj).to receive(:in_repo).and_return(false)
+      expect(sj).to receive(:in_repo?).and_return(false)
       expect(SugarJar::Log).to receive(:debug).with(/Skipping/)
       sj.send(:set_commit_template)
     end
@@ -27,7 +27,7 @@ describe 'SugarJar::Commands' do
         { 'commit_template' => '.commit_template.txt' },
       )
       sj = SugarJar::Commands.new({ 'no_change' => true })
-      expect(sj).to receive(:in_repo).and_return(true)
+      expect(sj).to receive(:in_repo?).and_return(true)
       expect(sj).to receive(:repo_root).and_return('/nonexistent')
       expect(File).to receive(:exist?).
         with('/nonexistent/.commit_template.txt').and_return(false)
@@ -40,7 +40,7 @@ describe 'SugarJar::Commands' do
         { 'commit_template' => '.commit_template.txt' },
       )
       sj = SugarJar::Commands.new({ 'no_change' => true })
-      expect(sj).to receive(:in_repo).and_return(true)
+      expect(sj).to receive(:in_repo?).and_return(true)
       expect(sj).to receive(:repo_root).and_return('/nonexistent')
       expect(File).to receive(:exist?).
         with('/nonexistent/.commit_template.txt').and_return(true)
@@ -57,7 +57,7 @@ describe 'SugarJar::Commands' do
         { 'commit_template' => '.commit_template.txt' },
       )
       sj = SugarJar::Commands.new({ 'no_change' => true })
-      expect(sj).to receive(:in_repo).and_return(true)
+      expect(sj).to receive(:in_repo?).and_return(true)
       expect(sj).to receive(:repo_root).and_return('/nonexistent')
       expect(File).to receive(:exist?).
         with('/nonexistent/.commit_template.txt').and_return(true)
@@ -77,7 +77,7 @@ describe 'SugarJar::Commands' do
         { 'commit_template' => '.commit_template.txt' },
       )
       sj = SugarJar::Commands.new({ 'no_change' => true })
-      expect(sj).to receive(:in_repo).and_return(true)
+      expect(sj).to receive(:in_repo?).and_return(true)
       expect(sj).to receive(:repo_root).and_return('/nonexistent')
       expect(File).to receive(:exist?).
         with('/nonexistent/.commit_template.txt').and_return(true)
@@ -104,11 +104,32 @@ describe 'SugarJar::Commands' do
       'http://github.com/org/repo.git',
       # https
       'https://github.com/org/repo.git',
-      # hub
+      # gh
       'org/repo',
     ].each do |url|
-      it "detects the org from #{url}" do
+      it "extracts the org from #{url}" do
         expect(sj.send(:extract_org, url)).to eq('org')
+      end
+    end
+  end
+
+  context '#extract_repo' do
+    let(:sj) do
+      SugarJar::Commands.new({ 'no_change' => true })
+    end
+
+    [
+      # ssh
+      'git@github.com:org/repo.git',
+      # http
+      'http://github.com/org/repo.git',
+      # https
+      'https://github.com/org/repo.git',
+      # gh
+      'org/repo',
+    ].each do |url|
+      it "extracts the repo from #{url}" do
+        expect(sj.send(:extract_repo, url)).to eq('repo')
       end
     end
   end
@@ -153,7 +174,7 @@ describe 'SugarJar::Commands' do
       end
     end
 
-    # hub
+    # gh
     url = 'org/repo'
     it "canonicalizes short name #{url}" do
       expect(sj.send(:canonicalize_repo, url)).


### PR DESCRIPTION
* We were checking to see if we could stack PRs based on comparing
the name of the upstream with the org of the push which.. are never
the same, so compare the actual orgs
* Rename a few functions to fit with ruby standard naming
* Add a simple unit test

Signed-off-by: Phil Dibowitz <phil@ipom.com>
