### PR TITLE
bclean: Handle worktrees gracefully

### DIFF
--- a/lib/sugarjar/commands.rb
+++ b/lib/sugarjar/commands.rb
@@ -307,6 +307,30 @@ class SugarJar
       exit(1)
     end
 
+    def worktree_branches
+      worktrees.values.map do |wt|
+        branch_from_ref(wt['branch'])
+      end
+    end
+
+    def worktrees
+      root = SugarJar::Util.repo_root
+      s = git('worktree', 'list', '--porcelain')
+      s.error!
+      worktrees = {}
+      # each entry is separated by a double newline
+      s.stdout.split("\n\n").each do |entry|
+        # then each key/val is split by a new line with the key and
+        # the value themselves split by a whitespace
+        tree = entry.split("\n").to_h(&:split)
+        # Skip the one
+        next if tree['worktree'] == root
+
+        worktrees[tree['worktree']] = tree
+      end
+      worktrees
+    end
+
     def branch_from_ref(ref, type = :local)
       # local branches are refs/head/XXXX
       # remote branches are refs/remotes/<remote>/XXXX

--- a/lib/sugarjar/commands/bclean.rb
+++ b/lib/sugarjar/commands/bclean.rb
@@ -4,6 +4,14 @@ class SugarJar
       assert_in_repo!
       name ||= current_branch
       name = fprefix(name)
+
+      wt_branches = worktree_branches
+
+      if wt_branches.include?(name)
+        SugarJar::Log.warn("#{name}: #{color('skipped', :yellow)} (worktree)")
+        return
+      end
+
       if clean_branch(name)
         SugarJar::Log.info("#{name}: #{color('reaped', :green)}")
       else
@@ -17,9 +25,16 @@ class SugarJar
     def bcleanall
       assert_in_repo!
       curr = current_branch
+      wt_branches = worktree_branches
       all_local_branches.each do |branch|
         if MAIN_BRANCHES.include?(branch)
           SugarJar::Log.debug("Skipping #{branch}")
+          next
+        end
+        if wt_branches.include?(branch)
+          SugarJar::Log.info(
+            "#{branch}: #{color('skipped', :yellow)} (worktree)",
+          )
           next
         end
 


### PR DESCRIPTION
When a branch is checked out as a worktree, you cannot switch to it.
As such we need to skip them when doing bclean{,all}.

Closes #195

Signed-off-by: Phil Dibowitz <phil@ipom.com>
