### PR TITLE
Release branch handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,24 @@ It looks like this is a subfeature, would you like to base this PR on mynewthing
 ...
 ```
 
+### Smart release branch handling
+
+You can tell sugar what release branches exist, and it will intelligently
+handle them. So of you specify, in your repoconfig:
+
+```yaml
+release_branches: ['v1-branch', 'v2-branch']
+```
+
+Then:
+
+* `sj feature v1-backport-foo v2-branch` will automatically base this
+  branch on `upstream/v2-branch` (or `origin/v2-branch` as appropriate)
+* `sj feature v2-branch` will checkout `v2-branch` with the upstream set
+  to `upstream/v2-branch` (or `origin/v2-branch` as appropriate)
+* `sj lbclean`/`sj lbcleanall` (of all varieties) will never reap release
+  branches
+
 ### Have a better lint/unittest experience!
 
 Ever made a PR, only to find out later that it failed tests because of some

--- a/lib/sugarjar/commands.rb
+++ b/lib/sugarjar/commands.rb
@@ -328,6 +328,10 @@ class SugarJar
       exit(1)
     end
 
+    def release_branches
+      @repo_config['release_branches'] || []
+    end
+
     def worktree_branches
       worktrees.values.map do |wt|
         branch_from_ref(wt['branch'])

--- a/lib/sugarjar/commands/bclean.rb
+++ b/lib/sugarjar/commands/bclean.rb
@@ -6,9 +6,17 @@ class SugarJar
       name = fprefix(name)
 
       wt_branches = worktree_branches
+      rel_branches = release_branches
 
       if wt_branches.include?(name)
         SugarJar::Log.warn("#{name}: #{color('skipped', :yellow)} (worktree)")
+        return
+      end
+
+      if rel_branches.include?(name)
+        SugarJar::Log.warn(
+          "#{name}: #{color('skipped', :yellow)} (release branch)",
+        )
         return
       end
 

--- a/lib/sugarjar/commands/feature.rb
+++ b/lib/sugarjar/commands/feature.rb
@@ -5,10 +5,32 @@ class SugarJar
       SugarJar::Log.debug("Feature: #{name}, #{base}")
       name = fprefix(name)
       die("#{name} already exists!") if all_local_branches.include?(name)
+      rel_branches = release_branches
       if base
-        fbase = fprefix(base)
-        base = fbase if all_local_branches.include?(fbase)
+        # If the user specified a base branch (sf mything base)
+        # we check if <base> is a release branch and if so, we make
+        # this track <upstream>/<base>
+        if rel_branches.include?(base)
+          newbase = "#{upstream}/#{base}"
+          SugarJar::Log.info(
+            "Base branch #{base} is a release branch, setting it to track " +
+            newbase,
+          )
+          base = newbase
+        else
+          fbase = fprefix(base)
+          base = fbase if all_local_branches.include?(fbase)
+        end
+      elsif rel_branches.include?(name)
+        # If the user did NOT specify a base *and* this new feature is
+        # a release branch, check it out tracking the upstream release
+        # branch instead of main
+        base = "#{upstream}/#{name}"
+        SugarJar::Log.info(
+          "Feature #{name} is a release branch, setting it to track #{base}",
+        )
       else
+        # otherwise, fallback to most-main
         base ||= most_main
       end
       # If our base is a local branch, don't try to parse it for a remote name
@@ -25,6 +47,7 @@ class SugarJar
     end
     alias f feature
 
+    # alias for "feature <current_branch>'
     def subfeature(name)
       assert_in_repo!
       SugarJar::Log.debug("Subfature: #{name}")

--- a/spec/commands/feature_spec.rb
+++ b/spec/commands/feature_spec.rb
@@ -5,47 +5,83 @@ describe 'SugarJar::Commands' do
     SugarJar::Commands.new({ 'no_change' => true })
   end
 
+  before(:each) do
+    expect(sj).to receive(:assert_in_repo!).and_return(true)
+  end
+
   context '#feature' do
-    it 'creates a branch based on remote-most-main-branch with no args' do
-      branch = 'foo'
-      expect(sj).to receive(:assert_in_repo!).and_return(true)
-      expect(sj).to receive(:fprefix).with(branch).and_return(branch)
-      expect(sj).to receive(:all_local_branches).at_least(1).times.
-        and_return(['main'])
-      expect(sj).to receive(:all_remotes).and_return(%w{upstream origin})
-      expect(sj).to receive(:git).with('fetch', 'upstream')
-      expect(sj).to receive(:git).with(
-        'checkout', '-b', branch, 'upstream/main'
-      )
-      expect(sj).to receive(:git).with('branch', '-u', 'upstream/main')
-      sj.feature(branch)
+    context 'with no specified base' do
+      it 'creates a branch based on remote-most-main-branch with no args' do
+        branch = 'foo'
+        expect(sj).to receive(:fprefix).with(branch).and_return(branch)
+        expect(sj).to receive(:all_local_branches).at_least(1).times.
+          and_return(['main'])
+        expect(sj).to receive(:all_remotes).and_return(%w{upstream origin})
+        expect(sj).to receive(:git).with('fetch', 'upstream')
+        expect(sj).to receive(:git).with(
+          'checkout', '-b', branch, 'upstream/main'
+        )
+        expect(sj).to receive(:git).with('branch', '-u', 'upstream/main')
+        sj.feature(branch)
+      end
+
+      it 'checks out a release branch properly' do
+        branch = 'v2-branch'
+        upstream_release = 'upstream/v2-branch'
+        expect(sj).to receive(:all_remotes).and_return(%w{origin upstream})
+        expect(sj).to receive(:fprefix).with(branch).and_return(branch)
+        expect(sj).to receive(:release_branches).and_return(['v2-branch'])
+        expect(sj).to receive(:all_local_branches).at_least(1).times.
+          and_return(['main'])
+        expect(sj).to receive(:git).with('fetch', 'upstream')
+        expect(sj).to receive(:git).
+          with('checkout', '-b', branch, upstream_release)
+        expect(sj).to receive(:git).with('branch', '-u', upstream_release)
+        sj.feature(branch)
+      end
     end
 
-    it 'creates a branch based on requested local branch with args' do
-      branch = 'foo'
-      base = 'bar'
-      expect(sj).to receive(:assert_in_repo!).and_return(true)
-      expect(sj).to receive(:fprefix).with(branch).and_return(branch)
-      expect(sj).to receive(:fprefix).with(base).and_return(base)
-      expect(sj).to receive(:all_local_branches).at_least(1).times.
-        and_return(['main', base])
-      expect(sj).to receive(:git).with('checkout', '-b', branch, base)
-      expect(sj).to receive(:git).with('branch', '-u', base)
-      sj.feature(branch, base)
-    end
+    context 'with specified base' do
+      it 'creates a branch based on requested local branch with args' do
+        branch = 'foo'
+        base = 'bar'
+        expect(sj).to receive(:all_local_branches).at_least(1).times.
+          and_return(['main', base])
+        expect(sj).to receive(:fprefix).with(branch).and_return(branch)
+        expect(sj).to receive(:fprefix).with(base).and_return(base)
+        expect(sj).to receive(:git).with('checkout', '-b', branch, base)
+        expect(sj).to receive(:git).with('branch', '-u', base)
+        sj.feature(branch, base)
+      end
 
-    it 'creates a branch based on requested remote branch with args' do
-      branch = 'foo'
-      base = 'upstream/bar'
-      expect(sj).to receive(:assert_in_repo!).and_return(true)
-      expect(sj).to receive(:fprefix).with(branch).and_return(branch)
-      expect(sj).to receive(:fprefix).with(base).and_return(base)
-      expect(sj).to receive(:all_local_branches).at_least(1).times.
-        and_return(['main'])
-      expect(sj).to receive(:git).with('fetch', 'upstream')
-      expect(sj).to receive(:git).with('checkout', '-b', branch, base)
-      expect(sj).to receive(:git).with('branch', '-u', base)
-      sj.feature(branch, base)
+      it 'creates a branch based on requested remote branch with args' do
+        branch = 'foo'
+        base = 'upstream/bar'
+        expect(sj).to receive(:fprefix).with(branch).and_return(branch)
+        expect(sj).to receive(:fprefix).with(base).and_return(base)
+        expect(sj).to receive(:all_local_branches).at_least(1).times.
+          and_return(['main'])
+        expect(sj).to receive(:git).with('fetch', 'upstream')
+        expect(sj).to receive(:git).with('checkout', '-b', branch, base)
+        expect(sj).to receive(:git).with('branch', '-u', base)
+        sj.feature(branch, base)
+      end
+
+      it 'creates a subfeature based on the proper upstream release' do
+        base = 'v2-branch'
+        upstream_release = 'upstream/v2-branch'
+        branch = 'my-v2-work'
+        expect(sj).to receive(:all_remotes).and_return(%w{origin upstream})
+        expect(sj).to receive(:fprefix).with(branch).and_return(branch)
+        expect(sj).to receive(:release_branches).and_return(['v2-branch'])
+        expect(sj).to receive(:all_local_branches).at_least(1).times.
+          and_return(['main'])
+        expect(sj).to receive(:git).with('fetch', 'upstream')
+        expect(sj).to receive(:git).
+          with('checkout', '-b', branch, upstream_release)
+        expect(sj).to receive(:git).with('branch', '-u', upstream_release)
+        sj.feature(branch, base)
+      end
     end
   end
 end


### PR DESCRIPTION
If you add `release_branches` to your repo config, this will enable
SugarJar to be smarter about them:

* It will never reap them (in any branchclean command)
* When you check them out it will automatically setup tracking
  currectly
* When you subfeature them, it will automatically setup tracking
  currectly

Signed-off-by: Phil Dibowitz <phil@ipom.com>
