### PR TITLE
When in manual lint/unit, allow user to skip amending

### DIFF
--- a/lib/sugarjar/commands/checks.rb
+++ b/lib/sugarjar/commands/checks.rb
@@ -22,12 +22,12 @@ class SugarJar
           exit(1)
         end
       end
-      exit(1) unless run_check('lint')
+      exit(1) unless run_check('lint', false)
     end
 
     def unit
       assert_in_repo!
-      exit(1) unless run_check('unit')
+      exit(1) unless run_check('unit', false)
     end
 
     def get_checks_from_command(type)
@@ -71,7 +71,13 @@ class SugarJar
       @checks[type]
     end
 
-    def run_check(type)
+    # autorun is true when we're running from push, and false when someone
+    # ran 'lint' or 'unit' directly
+    #
+    # In the case of a autorun, if a linter changes the code, we require
+    # either the user amend, or bail out. If it's a manual run, then we
+    # allow them to just go on.
+    def run_check(type, autorun)
       repo_root = SugarJar::Util.repo_root
       Dir.chdir repo_root do
         checks = get_checks(type)
@@ -81,6 +87,7 @@ class SugarJar
 
         checks.each do |check|
           SugarJar::Log.debug("Running #{type} #{check}")
+          skip_redo = false
 
           short = check.split.first
           if short.include?('/')
@@ -104,10 +111,15 @@ class SugarJar
             )
             puts git('diff').stdout
             loop do
-              $stdout.print(
-                "\nWould you like to\n\t[q]uit and inspect\n\t[a]mend the " +
-                "changes to the current commit and re-run\n  > ",
-              )
+              options = [
+                '[q]uit and inspect',
+                '[a]mend the changes to the current commit and re-run',
+              ]
+              options << '[i]gnore the changes and keep going' unless autorun
+
+              msg = "\nWould you like to\n\t" + options.join("\n\t") + "\n  > "
+
+              $stdout.print(msg)
               ans = $stdin.gets.strip
               case ans
               when /^q/
@@ -118,9 +130,14 @@ class SugarJar
                 # break here, if we get out of this loop we 'redo', assuming
                 # the user chose this option
                 break
+              when /^i/
+                unless autorun
+                  skip_redo = true
+                  break
+                end
               end
             end
-            redo
+            redo unless skip_redo
           end
 
           if s.error?

--- a/lib/sugarjar/commands/push.rb
+++ b/lib/sugarjar/commands/push.rb
@@ -43,7 +43,7 @@ class SugarJar
     def run_prepush
       @repo_config['on_push']&.each do |item|
         SugarJar::Log.debug("Running on_push check type #{item}")
-        unless run_check(item)
+        unless run_check(item, true)
           SugarJar::Log.info("[prepush]: #{item} #{color('failed', :red)}.")
           return false
         end

--- a/spec/commands/checks_spec.rb
+++ b/spec/commands/checks_spec.rb
@@ -126,7 +126,7 @@ describe 'SugarJar::Commands' do
       expect($stdin).to receive(:gets).and_return("a\n")
       expect(sj).to receive(:qamend).with('-a')
       expect(sj).to receive(:dirty?).and_return(false)
-      sj.run_check('lint')
+      sj.run_check('lint', true)
     end
 
     it 'quits if linter autocorrects and user says no' do
@@ -150,7 +150,7 @@ describe 'SugarJar::Commands' do
         raise SystemExit, 1
       end
       expect do
-        sj.run_check('lint')
+        sj.run_check('lint', true)
       end.to raise_error(SystemExit)
     end
 
@@ -169,7 +169,7 @@ describe 'SugarJar::Commands' do
         expect(Mixlib::ShellOut).to receive(:new).with(cmd).and_return(so)
         expect(so).to receive(:run_command).and_return(so)
         expect(sj).to receive(:dirty?).and_return(false) if type == 'lint'
-        expect(sj.run_check(type)).to eq(false)
+        expect(sj.run_check(type, true)).to eq(false)
       end
     end
   end


### PR DESCRIPTION
Allow the user to ignore amending changes when running linters manually.

We wouldn't want this on `smartpush`, but it's not unreasonable in
`lint` itself.

Closes #209

Signed-off-by: Phil Dibowitz <phil@ipom.com>
