### PR TITLE
Add support for gitlab

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -15,7 +15,8 @@ frustrated when [...]
 A clear and concise description of what you want to happen.
 
 **Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
+A clear and concise description of any alternative solutions or features you've
+considered.
 
 **Contribution**
 Are you willing to write this feature? If so, would you need assistance?

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -24,13 +24,17 @@ jobs:
       with:
         egress-policy: audit
 
+    - name: Install system dependencies
+      run: |-
+        sudo apt update
+        sudo apt install -y gh glab
     - name: Checkout repository
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Setup Ruby
       uses: ruby/setup-ruby@4eb9f110bac952a8b68ecf92e3b5c7a987594ba6 # v1.292.0
       with:
         ruby-version: ${{ matrix.ruby }}
-    - name: Install dependencies
+    - name: Install Ruby dependencies
       run: bundle install
     - name: Run rspec
       run: ./scripts/run_rspec.sh

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -4,10 +4,10 @@
 
 In the interest of fostering an open and welcoming environment, we as
 contributors and maintainers pledge to making participation in our project and
-our community a harassment-free experience for everyone, regardless of age, body
-size, disability, ethnicity, sex characteristics, gender identity and expression,
-level of experience, education, socio-economic status, nationality, personal
-appearance, race, religion, or sexual identity and orientation.
+our community a harassment-free experience for everyone, regardless of age,
+body size, disability, ethnicity, sex characteristics, gender identity and
+expression, level of experience, education, socio-economic status, nationality,
+personal appearance, race, religion, or sexual identity and orientation.
 
 ## Our Standards
 
@@ -55,11 +55,11 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at phil@ipom.com. All
-complaints will be reviewed and investigated and will result in a response that
-is deemed necessary and appropriate to the circumstances. The project team is
-obligated to maintain confidentiality with regard to the reporter of an incident.
-Further details of specific enforcement policies may be posted separately.
+reported by contacting the project team at phil@ipom.com. All complaints will
+be reviewed and investigated and will result in a response that is deemed
+necessary and appropriate to the circumstances. The project team is obligated
+to maintain confidentiality with regard to the reporter of an incident. Further
+details of specific enforcement policies may be posted separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good
 faith may face temporary or permanent repercussions as determined by other

--- a/README.md
+++ b/README.md
@@ -1,12 +1,21 @@
 # SugarJar
 
-[![Lint](https://github.com/jaymzh/sugarjar/workflows/Lint/badge.svg)](https://github.com/jaymzh/sugarjar/actions?query=workflow%3ALint)
-[![Unittest](https://github.com/jaymzh/sugarjar/workflows/Unittests/badge.svg)](https://github.com/jaymzh/sugarjar/actions?query=workflow%3AUnittests)
-[![DCO](https://github.com/jaymzh/sugarjar/workflows/DCO%20Check/badge.svg)](https://github.com/jaymzh/sugarjar/actions?query=workflow%3A%22DCO+Check%22)
-[![CodeQL](https://github.com/jaymzh/sugarjar/actions/workflows/codeql.yml/badge.svg)](https://github.com/jaymzh/sugarjar/actions/workflows/codeql.yml)
+[![Lint](
+https://github.com/jaymzh/sugarjar/workflows/Lint/badge.svg
+)](https://github.com/jaymzh/sugarjar/actions?query=workflow%3ALint)
+[![Unittest](
+https://github.com/jaymzh/sugarjar/workflows/Unittests/badge.svg
+)](https://github.com/jaymzh/sugarjar/actions?query=workflow%3AUnittests)
+[![DCO](
+https://github.com/jaymzh/sugarjar/workflows/DCO%20Check/badge.svg
+)](https://github.com/jaymzh/sugarjar/actions?query=workflow%3A%22DCO+Check%22)
+[![CodeQL](
+https://github.com/jaymzh/sugarjar/actions/workflows/codeql.yml/badge.svg
+)](https://github.com/jaymzh/sugarjar/actions/workflows/codeql.yml)
 
-Welcome to SugarJar - a git/github helper. The only requirements are Ruby,
-`git`, and [gh](https://cli.github.com/).
+Welcome to SugarJar - a git + github/gitlab helper. The only requirements are
+Ruby, `git`, and either [gh](https://cli.github.com/) or
+[glab](https://docs.gitlab.com/cli/), depending on which forge you are using.
 
 SugarJar is inspired by [arcanist](https://github.com/phacility/arcanist), and
 its replacement at Facebook, JellyFish. Many of the features they provide for
@@ -24,9 +33,12 @@ Jump to what you're most interested in:
 * [Common Use-cases](#common-use-cases)
    * [Auto Cleanup Squash-merged branches](#auto-cleanup-squash-merged-branches)
    * [Smarter clones and remotes](#smarter-clones-and-remotes)
-   * [Work with stacked branches more easily](#work-with-stacked-branches-more-easily)
-   * [Creating Stacked PRs with subfeatures](#creating-stacked-prs-with-subfeatures)
-   * [Have a better lint/unittest experience!](#have-a-better-lintunittest-experience)
+   * [Work with stacked branches more easily](
+     #work-with-stacked-branches-more-easily)
+   * [Creating Stacked PRs with subfeatures](
+     #creating-stacked-prs-with-subfeatures)
+   * [Have a better lint/unittest experience!](
+     #have-a-better-lintunittest-experience)
    * [Better push defaults](#better-push-defaults)
    * [Cleaning up your own history](#cleaning-up-your-own-history)
    * [Better feature branches](#better-feature-branches)
@@ -57,7 +69,9 @@ and safely deletes if so. (Note: `lbclean` stands for "local branch clean", and
 is aliased to `bclean` for both backwards-compatibility and also since it's the
 most common branch-cleanup command).
 
-![bclean screenshot](https://github.com/jaymzh/sugarjar/blob/main/images/bclean.png)
+![bclean screenshot](
+https://github.com/jaymzh/sugarjar/blob/main/images/bclean.png
+)
 
 Will delete a branch, if it has been merged, **even if it was squash-merged**.
 
@@ -67,7 +81,9 @@ You can pass it a branch if you'd like (it defaults to the branch you're on):
 But it gets better! You can use `sj bcleanall` to remove all branches that have
 been merged:
 
-![bcleanall screenshot](https://github.com/jaymzh/sugarjar/blob/main/images/bcleanall.png)
+![bcleanall screenshot](
+https://github.com/jaymzh/sugarjar/blob/main/images/bcleanall.png
+)
 
 There is also `sj rbclean` ("remote branch clean") (and `sj rbcleanall`) for
 cleanup of remote branches. *Note*: This cannot differentiate between
@@ -75,8 +91,8 @@ PR/feature branches which have been merged and long-lived release branches that
 have been merged (e.g.  if '2.0-release' is a branch and has no commits not in
 main, it will be deleted).
 
-There is even `sj gbclean` ("global branch clean") (and `sj gbcleanall`) which will
-do both the local and remote cleaning.
+There is even `sj gbclean` ("global branch clean") (and `sj gbcleanall`) which
+will do both the local and remote cleaning.
 
 *NOTE*: Remote branch cleaning is still experimental, use with caution!
 
@@ -86,7 +102,9 @@ There's a pattern to every new repo we want to contribute to. First we fork,
 then we clone the fork, then we add a remote of the upstream repo. It's
 monotonous. SugarJar does this for you:
 
-![smartclone screenshot](https://github.com/jaymzh/sugarjar/blob/main/images/sclone.png)
+![smartclone screenshot](
+https://github.com/jaymzh/sugarjar/blob/main/images/sclone.png
+)
 
 `sj` accepts both `smartclone` and `sclone` for this command.
 
@@ -113,7 +131,9 @@ First, and foremost, is `feature` and `subfeature`. Regardless of stacking, the
 way to create a new feature bracnh with sugarjar is with `sj feature` (or `sj
 f` for short):
 
-![feature screenshot](https://github.com/jaymzh/sugarjar/blob/main/images/feature.png)
+![feature screenshot](
+https://github.com/jaymzh/sugarjar/blob/main/images/feature.png
+)
 
 A "feature" in SugarJar parlance just means that the branch is always created
 from "most main" - this is usually `upstream/main`, but SJ will figure out
@@ -124,7 +144,9 @@ to fetch that remote first to make sure you're working on the latest HEAD.
 When you want to create a stacked PR, you can create `subfeature`, which, at
 its core is just a branch created from the current branch:
 
-![subfeature screenshot](https://github.com/jaymzh/sugarjar/blob/main/images/subfeature.png)
+![subfeature screenshot](
+https://github.com/jaymzh/sugarjar/blob/main/images/subfeature.png
+)
 
 If you create branches like this then sugarjar can now make several things
 much easier:
@@ -135,31 +157,41 @@ much easier:
 
 There are two commands that will show you the state of your stacked branches:
 
-* `sj binfo` - shows the current branch and its ancestors up to your primary branch
+* `sj binfo` - shows the current branch and its ancestors up to your primary
+  branch
 * `sj smartlog` (aka `sj sl`) - shows you the whole tree.
 
 To continue with the example above, my `smartlog` might look like:
 
-![subfeature-smartlog screenshot](https://github.com/jaymzh/sugarjar/blob/main/images/subfeature-smartlog.png)
+![subfeature-smartlog screenshot](
+https://github.com/jaymzh/sugarjar/blob/main/images/subfeature-smartlog.png
+)
 
 As you can see, `mynewthing` is derived from `main`, and `dependentnewthing` is
 derived from `mynewthing`.
 
 Now lets make a different feature stack:
 
-![subfeature-part2 screenshot](https://github.com/jaymzh/sugarjar/blob/main/images/subfeature-part2.png)
+![subfeature-part2 screenshot](
+https://github.com/jaymzh/sugarjar/blob/main/images/subfeature-part2.png
+)
 
 The `smartlog` will now show us this tree, and it's a bit more interesting:
 
-![subfeature-part2-smartlog screenshot](https://github.com/jaymzh/sugarjar/blob/main/images/subfeature-part2-smartlog.png)
+![subfeature-part2-smartlog screenshot](
+https://github.com/jaymzh/sugarjar/blob/main/images/subfeature-part2-smartlog.png
+)
 
 Here we can see from `main`, we have two branches: one going to `mynewthing`
 and one going to `anotherfeature`. Each of those has their own dependent branch
 on top.
 
-Now, what happens if I make a change to `mynewthing` (the bottom of the first stack)?
+Now, what happens if I make a change to `mynewthing` (the bottom of the first
+stack)?
 
-![subfeature-part3 screenshot](https://github.com/jaymzh/sugarjar/blob/main/images/subfeature-part3.png)
+![subfeature-part3 screenshot](
+https://github.com/jaymzh/sugarjar/blob/main/images/subfeature-part3.png
+)
 
 We can see here now that `dependentnewthing`, is based off a commit that _used_
 to be `mynewthing` (`5086ee`), but `mynewthing` has moved. Both `mynewthing`
@@ -167,7 +199,9 @@ and `dependentnewthing` are derived from `5086ee` (the old `mynewthing`), but
 `dependentnewthing` isn't (yet) based on the current `mynewthing`. But SugarJar
 will handle this all correctly when we ask it to update the branch:
 
-![subfeature-part3-rebase screenshot](https://github.com/jaymzh/sugarjar/blob/main/images/subfeature-part3-rebase.png)
+![subfeature-part3-rebase screenshot](
+https://github.com/jaymzh/sugarjar/blob/main/images/subfeature-part3-rebase.png
+)
 
 Here we see that SugarJar knew that `dependentnewthing` should be rebased onto
 `mynewthing`, and it did the right thing - from main there's still the
@@ -178,7 +212,9 @@ including all 3 commits in the right order.
 Now, lets say that `mynewthing` gets merged and we use `bclean` to clean it all
 up, what happens then?
 
-![subfeature-detect-missing-base screenshot](https://github.com/jaymzh/sugarjar/blob/main/images/subfeature-detect-missing-base.png)
+![subfeature-detect-missing-base screenshot](
+https://github.com/jaymzh/sugarjar/blob/main/images/subfeature-detect-missing-base.png
+)
 
 SugarJar detects that branch is gone and thus this branch should now be based
 on the upstream main branch!
@@ -295,8 +331,9 @@ Created feature branch dependent-feature based on test-branch
 
 Additionally you can specify a `feature_prefix` in your config which will cause
 `feature` to create branches prefixed with your `feature_prefix` and will also
-cause `co` to checkout branches with that prefix. This is useful when organizations
-use branch-based workflows and branches need to be prefixed with e.g. `$USER/`.
+cause `co` to checkout branches with that prefix. This is useful when
+organizations use branch-based workflows and branches need to be prefixed with
+e.g. `$USER/`.
 
 For example, if your prefix was `user/`, then `sj feature foo` would create
 `user/foo`, and `sj co foo` would switch to `user/foo`.
@@ -306,7 +343,9 @@ For example, if your prefix was `user/`, then `sj feature foo` would create
 Smartlog will show you a tree diagram of your branches! Simply run `sj
 smartlog` or `sj sl` for short.
 
-![smartlog screenshot](https://github.com/jaymzh/sugarjar/blob/main/images/smartlog.png)
+![smartlog screenshot](
+https://github.com/jaymzh/sugarjar/blob/main/images/smartlog.png
+)
 
 ### Sync work across workstations
 
@@ -341,15 +380,17 @@ See `sj help` for more commands!
 Sugarjar is packaged in a variety of Linux distributions - see if it's on the
 list here, and if so, use your package manager (or `gem`) to install it:
 
-[![Packaging status](https://repology.org/badge/vertical-allrepos/sugarjar.svg?exclude_unsupported=1)](https://repology.org/project/sugarjar/versions)
+[![Packaging status](
+https://repology.org/badge/vertical-allrepos/sugarjar.svg?exclude_unsupported=1
+)](https://repology.org/project/sugarjar/versions)
 
 If you are using a Linux distribution version that is end-of-life'd, click the
 above image, it'll take you to a page that lists unsupported distro versions
 as well (they'll have older SugarJar, but they'll probably still have some
 version).
 
-**Ubuntu users**: You can use [this
-PPA](https://launchpad.net/~michel-slm/+archive/ubuntu/sugarjar) to get newer
+**Ubuntu users**: You can use [this PPA](
+https://launchpad.net/~michel-slm/+archive/ubuntu/sugarjar) to get newer
 versions for all supported Ubuntu releases (as well as some older versions).
 Ubuntu package maintainer.
 
@@ -371,8 +412,8 @@ See [examples/sample_config.yaml](examples/sample_config.yaml) for an example
 configuration file.
 
 In addition, the environment variable `SUGARJAR_LOGLEVEL` can be defined to set
-a log level. This is primarily used as a way to turn debug on earlier in order to
-troubleshoot configuration parsing.
+a log level. This is primarily used as a way to turn debug on earlier in order
+to troubleshoot configuration parsing.
 
 Deprecated fields will cause a warning, but you can suppress that warning by
 defining `ignore_deprecated_options`, for example:
@@ -399,29 +440,30 @@ commit template by dropping a file in the repo. Users must do something like:
 `git config commit.template <file>`. Making each developer do this is error
 prone, so this setting will automatically set this up for each developer.
 
-## Enterprise GitHub
+## Enterprise GitHub/GitLab
 
-Like `gh`, SugarJar supports GitHub Enterprise. In fact, we provide extra
-features just for it.
+Like `gh` and `glab`, SugarJar supports Enterprise versions of GitHub and
+GitLab. In fact, we provide extra features just for it.
 
-You can set `github_host` in your global or user config, but since most
+In most cases, when using `sj smartclone`, pass in `--forge-host`, and
+that's about all you need, everything else should be handlded automagically.
+
+However, you can set `forge_host` in your global or user config, but since most
 users will also have a few opensource repos, you can override it in the
 Repository Config as well.
 
 So, for example you might have:
 
 ```yaml
-github_host: gh.sample.com
+forge_host: gh.sample.com
 ```
 
 In your `~/.config/sugarjar/config.yaml`, but if the `.sugarjar.yaml` in your
 repo has:
 
 ```yaml
-github_host: github.com
+forge_host: github.com
 ```
-
-Then we will configure `gh` to talk to github.com when in that repo.
 
 ## FAQ
 
@@ -452,12 +494,12 @@ simply source that in your dotfiles, assuming you are using bash.
 
 **What happens now that Sapling is released?**
 
-SugarJar isn't going anywhere anytime soon. This was meant to replace arc/jf,
-which has now been open-sourced as [Sapling](https://sapling-scm.com/), so I
-highly recommend taking a look at that!
+SugarJar isn't going anywhere. This was meant to replace arc/jf, which has now
+been open-sourced as [Sapling](https://sapling-scm.com/), so I highly recommend
+taking a look at that!
 
 Sapling is a great tool and solves a variety of problems SugarJar will never be
-able to. However, it is a significant workflow change, that won't be
-appropriate for all users or use-cases. Similarly there are workflows and tools
-that Sapling breaks. So worry not, SugarJar will continue to be maintained and
-developed.
+able to. However, it is a significant workflow change that won't be appropriate
+for all users or use-cases. Similarly there are workflows and tools that
+Sapling breaks. Further, we support some things Sapling does not. So worry not,
+SugarJar will continue to be maintained and developed.

--- a/bin/sj
+++ b/bin/sj
@@ -36,18 +36,34 @@ parser = OptionParser.new do |opts|
   end
 
   opts.on(
+    '--forge-host HOST',
     '--github-host HOST',
-    'The host for "hub". Note that we will set this in the local repo ' +
-    'config so there is no need to have multiple config files for multiple ' +
-    'github servers. Put your default one in your config file, and simply ' +
-    'specify this option the first time you clone or touch a repo and it ' +
-    'will be part of that repo until changed.',
+    'The host of your forge (github, gitlab, etc.). Generally only needed' +
+    ' when cloning (smartclone), as we can usually figure out from within' +
+    ' a cloned repo. Currently accepts --github-host for backwards' +
+    ' compatibility.',
   ) do |host|
-    options['github_host'] = host
+    options['forge_host'] = host
   end
 
-  opts.on('--github-user USER', 'Github username') do |user|
+  opts.on('--forge-type TYPE', 'Forge type: github, gitlab') do |type|
+    options['forge_type'] = type
+  end
+
+  opts.on(
+    '--github-user USER',
+    'User for github repos, unless specified in the repoconfig.' +
+    ' Defaults to your local username',
+  ) do |user|
     options['github_user'] = user
+  end
+
+  opts.on(
+    '--gitlab-user USER',
+    'User for gitlab repos, unless specified in the repoconfig.' +
+    ' Defaults to your local username',
+  ) do |user|
+    options['gitlab_user'] = user
   end
 
   opts.on('-h', '--help', 'Print this help message') do
@@ -310,6 +326,12 @@ end
 
 SugarJar::Log.debug("Final config: #{options}")
 
+# if the command is help, we don't bother to create the Commands obj
+if subcommand == 'help'
+  puts parser
+  exit
+end
+
 sj = SugarJar::Commands.new(options)
 valid_commands = sj.public_methods - Object.public_methods
 is_valid_command = valid_commands.include?(subcommand.to_sym)
@@ -325,13 +347,7 @@ SugarJar::Log.debug("subcommand is #{subcommand}")
 extra_opts += argv_copy
 SugarJar::Log.debug("extra unknown options: #{extra_opts}")
 
-case subcommand
-when 'help'
-  puts parser
-  exit
-when 'debuginfo'
-  extra_opts = [options]
-end
+extra_opts = [options] if subcommand == 'debuginfo'
 
 unless is_valid_command
   SugarJar::Log.fatal("No such subcommand: #{subcommand}")

--- a/examples/sample_repoconfig.yaml
+++ b/examples/sample_repoconfig.yaml
@@ -71,7 +71,13 @@ commit_template: .git_commit_template.txt
 
 github_user: myuser
 
-# `github_host` is the GitHub host to use when talking to GitHub (for hosted
-# GHE). See `github_user`.
+# `gitlab_user` is the user to use when talking to GitLab. Overrides any such
+# setting in the regular SugarJar config. Most useful when in the
+# `include_from` file.
 
-github_host: github.sample.com
+gitlab_user: myuser
+
+# `forge_host` is the GitHub/GitLab host to use when talking to hosted versions
+# of these services.
+
+forge_host: github.sample.com

--- a/lib/sugarjar/commands.rb
+++ b/lib/sugarjar/commands.rb
@@ -36,13 +36,27 @@ class SugarJar
       @checks = {}
       @main_branch = nil
       @main_remote_branches = {}
-      @ghuser = @repo_config['github_user'] || options['github_user']
-      @ghhost = @repo_config['github_host'] || options['github_host']
+      # This is CONFIGURED host, which may be null, as opposed
+      # to the method forge_host which will always return something
+      @_forge_host = @repo_config['forge_host'] || options['forge_host']
+      @repo_forge = @repo_config['forge_type'] || options['forge_type'] ||
+                    _determine_forge_type
 
-      die("No 'gh' found, please install 'gh'") unless gh_avail?
+      unless @repo_forge.nil?
+        cmd = _forge_cmd
+        unless SugarJar::Util.which_nofail(cmd)
+          die("No '#{cmd}' found, please install it'")
+        end
+      end
 
-      # Tell the 'gh' cli where to talk to, if not github.com
-      ENV['GH_HOST'] = @ghhost if @ghhost
+      user_option = "#{@repo_forge}_user"
+      @forge_user = @repo_config[user_option] || options[user_option]
+
+      # Tell the cli where to talk to, if not default
+      if @_forge_host
+        ENV['GH_HOST'] = @_forge_host
+        ENV['GL_HOST'] = @_forge_host
+      end
 
       return if options['no_change']
 
@@ -52,12 +66,8 @@ class SugarJar
     private
 
     def forked_repo(repo, username)
-      repo = if repo.start_with?('http', 'git@')
-               File.basename(repo)
-             else
-               "#{File.basename(repo)}.git"
-             end
-      "git@#{@ghhost || 'github.com'}:#{username}/#{repo}"
+      repo = extract_repo(repo)
+      "git@#{forge_host}:#{username}/#{repo}.git"
     end
 
     # gh utils will default to https, but we should always default to SSH
@@ -66,10 +76,39 @@ class SugarJar
       # if they fully-qualified it, we're good
       return repo if repo.start_with?('http', 'git@')
 
-      # otherwise, ti's a shortname
-      cr = "git@#{@ghhost || 'github.com'}:#{repo}.git"
+      # otherwise, it's a shortname
+      cr = "git@#{forge_host}:#{repo}.git"
       SugarJar::Log.debug("canonicalized #{repo} to #{cr}")
       cr
+    end
+
+    def forge_host
+      # if one is specifically configured, use that
+      return @_forge_host if @_forge_host
+
+      # otherwise, if we're in a repo, use the hostname of the remote
+      if SugarJar::Util.in_repo?
+        extract_host(remote_url_map['origin'])
+      else
+        @repo_forge == 'gitlab' ? 'gitlab.com' : 'github.com'
+      end
+    end
+
+    def repo_shortname(repo)
+      # if it's already a shortname, return
+      return repo unless repo.start_with?('http', 'git@')
+
+      # otherwise, parse it
+      if repo.start_with?('http')
+        bits = repo.split('/')
+      elsif repo.start_with?('git@')
+        relevant = repo.split(':').last
+        bits = relevant.split('/')
+      end
+      repo = bits[-1].gsub('.git', '')
+      org = bits[-2]
+
+      "#{org}/#{repo}"
     end
 
     def set_commit_template
@@ -137,7 +176,11 @@ class SugarJar
     end
 
     def determine_main_branch(branches)
-      branches.include?('main') ? 'main' : 'master'
+      if branches.include?('main')
+        'main'
+      elsif branches.include?('master')
+        'master'
+      end
     end
 
     def main_branch
@@ -263,7 +306,7 @@ class SugarJar
 
     # Whatever org we push to, regardless of if this is a fork or not
     def push_org
-      url = git('remote', 'get-url', 'origin').stdout.strip
+      url = remote_url_map['origin']
       extract_org(url)
     end
 
@@ -282,8 +325,8 @@ class SugarJar
       end
     end
 
-    def gh_avail?
-      !!SugarJar::Util.which_nofail('gh')
+    def forge_cli_avail?
+      !!SugarJar::Util.which_nofail(_forge_cmd)
     end
 
     def fprefix(name)
@@ -321,6 +364,14 @@ class SugarJar
 
     def extract_repo(repo)
       File.basename(repo, '.git')
+    end
+
+    def extract_host(repo)
+      if repo.start_with?('git@')
+        repo.split(':').first.split('@').last
+      elsif repo.start_with?('http')
+        repo.split('/')[2]
+      end
     end
 
     def die(msg)
@@ -377,12 +428,36 @@ class SugarJar
       SugarJar::Util.git_nofail(*, :color => @color)
     end
 
-    def ghcli(*)
-      SugarJar::Util.ghcli(*)
+    def _determine_forge_type
+      return nil unless SugarJar::Util.in_repo?
+
+      if remote_url_map.values.any? do |x|
+        x.include?('gitlab')
+      end
+        'gitlab'
+      else
+        'github'
+      end
     end
 
-    def ghcli_nofail(*)
-      SugarJar::Util.ghcli_nofail(*)
+    def _forge_cmd
+      @repo_forge == 'gitlab' ? 'glab' : 'gh'
+    end
+
+    def forge(*)
+      if @repo_forge == 'gitlab'
+        SugarJar::Util.glcli(*)
+      else
+        SugarJar::Util.ghcli(*)
+      end
+    end
+
+    def forge_nofail(*)
+      if @repo_forge == 'gitlab'
+        SugarJar::Util.glcli_nofail(*)
+      else
+        SugarJar::Util.ghcli_nofail(*)
+      end
     end
   end
 end

--- a/lib/sugarjar/commands/debuginfo.rb
+++ b/lib/sugarjar/commands/debuginfo.rb
@@ -4,7 +4,7 @@ class SugarJar
   class Commands
     def debuginfo(*args)
       puts "sugarjar version #{SugarJar::VERSION}"
-      puts ghcli('version').stdout
+      puts forge('version').stdout
       puts git('version').stdout
 
       puts "Config: #{JSON.pretty_generate(args[0])}"

--- a/lib/sugarjar/commands/smartclone.rb
+++ b/lib/sugarjar/commands/smartclone.rb
@@ -1,7 +1,7 @@
 class SugarJar
   class Commands
     def smartclone(repo, dir = nil, *)
-      reponame = File.basename(repo, '.git')
+      reponame = extract_repo(repo)
       dir ||= reponame
       org = extract_org(repo)
 
@@ -13,10 +13,15 @@ class SugarJar
       #
       # Unless the repo is in our own org and cannot be forked, then it
       # will fail.
-      if org == @ghuser
+      if org == @forge_user
         git('clone', canonicalize_repo(repo), dir, *)
       else
-        ghcli('repo', 'fork', '--clone', canonicalize_repo(repo), dir, *)
+        if @repo_forge == 'gitlab'
+          _gitlab_clone(org, repo, dir, *)
+        else
+          forge('repo', 'fork', '--clone', canonicalize_repo(repo), dir, *)
+        end
+
         # make the main branch track upstream
         Dir.chdir dir do
           git('branch', '-u', "upstream/#{main_branch}")
@@ -26,5 +31,44 @@ class SugarJar
       SugarJar::Log.info('Remotes "origin" and "upstream" configured.')
     end
     alias sclone smartclone
+
+    def _gitlab_clone(_org, repo, dir, *)
+      # The gitlab CLI is much less forgiving about already-forked
+      # repos, and it has no option to clone to a differently-named
+      # directory. So we have to special case it.
+
+      # glab requires a short-name for the fork command...
+      shortname = repo_shortname(repo)
+
+      # We call fork without --clone since --clone can't clone
+      # to another directory. Also, we must specify =false, or it
+      # will prompt
+      s = forge_nofail('repo', 'fork', shortname, '--clone=false')
+
+      # It fails with:
+      #    409 {message: [Project namespace name has already been taken,
+      #         Name has already been taken, Path has already been taken]}
+      #
+      # when there's already a fork... or if you happen to have a name
+      # collision. There's no way to tell, so we assume it means we've
+      # already forked.
+      if s.error?
+        if s.stderr.include?(' 409 ')
+          SugarJar::Log.debug('Forking failed, probably already forked')
+        else
+          s.error!
+        end
+      end
+
+      # Now we clone ourselves...
+      git('clone', canonicalize_repo(repo), dir, *)
+      Dir.chdir dir do
+        # and then configure remotes properly
+        git('remote', 'rename', 'origin', 'upstream')
+
+        fork_url = forked_repo(repo, @forge_user)
+        git('remote', 'add', 'origin', fork_url)
+      end
+    end
   end
 end

--- a/lib/sugarjar/commands/smartpullrequest.rb
+++ b/lib/sugarjar/commands/smartpullrequest.rb
@@ -60,16 +60,35 @@ class SugarJar
 
       # <org>:<branch> is the GH API syntax for:
       #   look for a branch of name <branch>, from a fork in owner <org>
-      args.unshift('--head', "#{push_org}:#{curr}")
-      SugarJar::Log.trace("Running: gh pr create #{args.join(' ')}")
-      gh = SugarJar::Util.which('gh')
-      system(gh, 'pr', 'create', *args)
+      if @repo_forge == 'github'
+        # On GitHub, the head is the org and the *BRANCH* name to use as
+        # the head branch...
+        args.unshift('--head', "#{push_org}:#{curr}")
+      else
+        # On GitLab, the head is the repo (org/repo) to use as the head
+        # _repo_, and then branch is configured seperately (with -s), but
+        # we don't need that since it defaults to the local branch name.
+        #
+        # Then we need --yes for it to not prompt us
+        args.unshift('--head', "#{push_org}/#{reponame}", '--yes')
+      end
+
+      bin = SugarJar::Util.which(_forge_cmd)
+      subcmd = _pr_cmd
+      SugarJar::Log.trace(
+        "Running: #{bin} #{subcmd} create #{args.join(' ')}",
+      )
+      system(bin, subcmd, 'create', *args)
     end
 
     alias spr smartpullrequest
     alias smartpr smartpullrequest
 
     private
+
+    def _pr_cmd
+      @repo_forge == 'gitlab' ? 'mr' : 'pr'
+    end
 
     def assert_common_main_branch!
       upstream_branch = main_remote_branch(upstream)
@@ -87,7 +106,9 @@ class SugarJar
       return if upstream_branch == 'origin'
 
       origin_branch = main_remote_branch('origin')
-      return if origin_branch == upstream_branch
+      # NOTE: that on GL, forks don't fork any branches by default, even
+      # a main one, so if it's 'nil', then ignore.
+      return if origin_branch.nil? || origin_branch == upstream_branch
 
       die(
         "The main branch of your upstream (#{upstream_branch}) and your " +

--- a/lib/sugarjar/config.rb
+++ b/lib/sugarjar/config.rb
@@ -7,6 +7,7 @@ class SugarJar
   class Config
     DEFAULTS = {
       'github_user' => ENV.fetch('USER'),
+      'gitlab_user' => ENV.fetch('USER'),
       'pr_autofill' => true,
       'pr_autostack' => nil,
       'color' => true,

--- a/lib/sugarjar/util.rb
+++ b/lib/sugarjar/util.rb
@@ -46,16 +46,36 @@ class SugarJar
       s
     end
 
-    def self.ghcli_nofail(*args)
-      SugarJar::Log.trace("Running: gh #{args.join(' ')}")
-      gh = which('gh')
-      s = Mixlib::ShellOut.new([gh] + args).run_command
-      if s.error? && s.stderr.include?('gh auth')
+    def self.ghcli_nofail(*)
+      forge_nofail('gh', *)
+    end
+
+    def self.ghcli(*)
+      s = ghcli_nofail(*)
+      s.error!
+      s
+    end
+
+    def self.glcli_nofail(*)
+      forge_nofail('glab', *)
+    end
+
+    def self.glcli(*)
+      s = glcli_nofail(*)
+      s.error!
+      s
+    end
+
+    def self.forge_nofail(cli, *args)
+      SugarJar::Log.trace("Running: #{cli} #{args.join(' ')}")
+      bin = which(cli)
+      s = Mixlib::ShellOut.new([bin] + args).run_command
+      if s.error? && s.stderr.include?("#{cli} auth")
         SugarJar::Log.info(
-          'gh was run but no github token exists. Will run "gh auth login" ' +
-          "to force\ngh to authenticate...",
+          'glab was run but no gitlab token exists. Will run ' +
+          '"glab auth login" to force\ngh to authenticate...',
         )
-        unless system(gh, 'auth', 'login', '-p', 'ssh')
+        unless system(bin, 'auth', 'login', '-p', 'ssh')
           SugarJar::Log.fatal(
             'That failed, I will bail out. Hub needs to get a github ' +
             'token. Try running "gh auth login" (will list info about ' +
@@ -64,12 +84,6 @@ class SugarJar
           exit(1)
         end
       end
-      s
-    end
-
-    def self.ghcli(*)
-      s = ghcli_nofail(*)
-      s.error!
       s
     end
 

--- a/packaging/README-fedora.md
+++ b/packaging/README-fedora.md
@@ -7,8 +7,12 @@ This is mostly notes to myself.
 Some links and refs useful to keep handy
 
 * [Sugar Jar dist-git](https://src.fedoraproject.org/rpms/rubygem-sugarjar)
-* [Package Maintenance Guide](https://docs.fedoraproject.org/en-US/package-maintainers/Package_Maintenance_Guide/)
-* [Machines you can use](https://fedoraproject.org/wiki/Test_Machine_Resources_For_Package_Maintainers)
+* [Package Maintenance Guide](
+  https://docs.fedoraproject.org/en-US/package-maintainers/Package_Maintenance_Guide/
+  )
+* [Machines you can use](
+  https://fedoraproject.org/wiki/Test_Machine_Resources_For_Package_Maintainers
+  )
 
 ## Prep
 

--- a/spec/commands/smartclone_spec.rb
+++ b/spec/commands/smartclone_spec.rb
@@ -1,45 +1,149 @@
 require_relative '../../lib/sugarjar/commands'
 
 describe 'SugarJar::Commands' do
-  let(:sj) do
-    SugarJar::Commands.new({ 'no_change' => true, 'github_user' => 'myuser' })
+  let(:opts) do
+    { 'no_change' => true, 'github_user' => 'myuser' }
   end
-
   context '#smartclone' do
-    it 'uses git if the repo is in our own org' do
-      repo = 'git@github.com:myuser/repo.git'
-      expect(sj).to_not receive(:ghcli)
-      expect(sj).to receive(:git).with('clone', repo, 'repo')
-      sj.smartclone(repo)
+    let(:sj) do
+      SugarJar::Commands.new(opts)
     end
 
-    it 'uses gh if the repo is not in our own org and sets upstream' do
-      repo = 'git@github.com:somethingelse/repo.git'
-      expect(sj).to receive(:ghcli).with(
-        'repo', 'fork', '--clone', repo, 'repo'
-      )
-      expect(Dir).to receive(:chdir).with('repo').and_yield
-      expect(sj).to receive(:main_branch).and_return('main')
-      expect(sj).to receive(:git).with('branch', '-u', 'upstream/main')
-      sj.smartclone(repo)
+    context 'repo is in our own org' do
+      let(:repo) do
+        'git@github.com:myuser/repo.git'
+      end
+
+      it 'uses git' do
+        repo = 'git@github.com:myuser/repo.git'
+        expect(sj).to_not receive(:forge)
+        expect(sj).to receive(:git).with('clone', repo, 'repo')
+        sj.smartclone(repo)
+      end
+
+      it 'passes additional arguments to git' do
+        expect(sj).to_not receive(:forge)
+        expect(sj).to receive(:git).with('clone', repo, 'somedir',
+                                         '--something')
+        sj.smartclone(repo, 'somedir', '--something')
+      end
     end
 
-    it 'passes additional arguments to git clone' do
-      repo = 'git@github.com:myuser/repo.git'
-      expect(sj).to_not receive(:ghcli)
-      expect(sj).to receive(:git).with('clone', repo, 'somedir', '--something')
-      sj.smartclone(repo, 'somedir', '--something')
-    end
+    context 'repo is not in our own org' do
+      context 'github' do
+        let(:opts) do
+          {
+            'no_change' => true,
+            'github_user' => 'myuser',
+            'forge_type' => 'github',
+          }
+        end
 
-    it 'passes additional arguments to gh repo fork' do
-      repo = 'git@github.com:somethingelse/repo.git'
-      expect(sj).to receive(:ghcli).with(
-        'repo', 'fork', '--clone', repo, 'somedir', '--something'
-      )
-      expect(Dir).to receive(:chdir).with('somedir').and_yield
-      expect(sj).to receive(:main_branch).and_return('main')
-      expect(sj).to receive(:git).with('branch', '-u', 'upstream/main')
-      sj.smartclone(repo, 'somedir', '--something')
+        let(:repo) do
+          'git@github.com:somethingelse/repo.git'
+        end
+
+        it 'uses forge and sets upstream' do
+          expect(sj).to receive(:forge).with(
+            'repo', 'fork', '--clone', repo, 'repo'
+          )
+          expect(Dir).to receive(:chdir).with('repo').and_yield
+          expect(sj).to receive(:main_branch).and_return('main')
+          expect(sj).to receive(:git).with('branch', '-u', 'upstream/main')
+          sj.smartclone(repo)
+        end
+
+        it 'passes additional arguments to gh repo fork' do
+          expect(sj).to receive(:forge).with(
+            'repo', 'fork', '--clone', repo, 'somedir', '--something'
+          )
+          expect(Dir).to receive(:chdir).with('somedir').and_yield
+          expect(sj).to receive(:main_branch).and_return('main')
+          expect(sj).to receive(:git).with('branch', '-u', 'upstream/main')
+          sj.smartclone(repo, 'somedir', '--something')
+        end
+      end
+
+      context 'gitlab' do
+        let(:opts) do
+          {
+            'no_change' => true,
+            'github_user' => 'myuser',
+            'forge_type' => 'gitlab',
+          }
+        end
+
+        let(:repo) do
+          'git@gitlab.com:somethingelse/repo.git'
+        end
+
+        let(:shell_out) do
+          double('shell_out')
+        end
+
+        it 'uses forge and sets upstream' do
+          expect(sj).to receive(:forge_nofail).with(
+            'repo', 'fork', 'somethingelse/repo', '--clone=false'
+          ).and_return(shell_out)
+          expect(shell_out).to receive(:error?).and_return(false)
+          expect(sj).to receive(:git).with('clone', repo, 'repo')
+          expect(Dir).to receive(:chdir).with('repo').exactly(2).times.and_yield
+          expect(sj).to receive(:git).with('remote', 'rename', 'origin',
+                                           'upstream')
+          expect(sj).to receive(:forked_repo).and_return(
+            'git@gitlab.com:myuser/repo.git',
+          )
+          expect(sj).to receive(:git).with(
+            'remote', 'add', 'origin', 'git@gitlab.com:myuser/repo.git'
+          )
+          expect(sj).to receive(:main_branch).and_return('main')
+          expect(sj).to receive(:git).with('branch', '-u', 'upstream/main')
+          sj.smartclone(repo)
+        end
+
+        it 'ignores error 409 from "glab repo fork"' do
+          expect(sj).to receive(:forge_nofail).with(
+            'repo', 'fork', 'somethingelse/repo', '--clone=false'
+          ).and_return(shell_out)
+          expect(shell_out).to receive(:error?).and_return(true)
+          expect(shell_out).to receive(:stderr).and_return(' 409 ')
+          expect(sj).to receive(:git).with('clone', repo, 'repo')
+          expect(Dir).to receive(:chdir).with('repo').exactly(2).times.and_yield
+          expect(sj).to receive(:git).with('remote', 'rename', 'origin',
+                                           'upstream')
+          expect(sj).to receive(:forked_repo).and_return(
+            'git@gitlab.com:myuser/repo.git',
+          )
+          expect(sj).to receive(:git).with(
+            'remote', 'add', 'origin', 'git@gitlab.com:myuser/repo.git'
+          )
+          expect(sj).to receive(:main_branch).and_return('main')
+          expect(sj).to receive(:git).with('branch', '-u', 'upstream/main')
+          sj.smartclone(repo)
+        end
+
+        it 'passes additional arguments to git clone' do
+          expect(sj).to receive(:forge_nofail).with(
+            'repo', 'fork', 'somethingelse/repo', '--clone=false'
+          ).and_return(shell_out)
+          expect(shell_out).to receive(:error?).and_return(false)
+          expect(sj).to receive(:git).with('clone', repo, 'somedir',
+                                           '--something')
+          expect(Dir).to receive(:chdir).with('somedir').exactly(2).
+            times.and_yield
+          expect(sj).to receive(:git).with('remote', 'rename', 'origin',
+                                           'upstream')
+          expect(sj).to receive(:forked_repo).and_return(
+            'git@gitlab.com:myuser/repo.git',
+          )
+          expect(sj).to receive(:git).with(
+            'remote', 'add', 'origin', 'git@gitlab.com:myuser/repo.git'
+          )
+          expect(sj).to receive(:main_branch).and_return('main')
+          expect(sj).to receive(:git).with('branch', '-u', 'upstream/main')
+          sj.smartclone(repo, 'somedir', '--something')
+        end
+      end
     end
   end
 end

--- a/spec/commands_spec.rb
+++ b/spec/commands_spec.rb
@@ -110,7 +110,7 @@ describe 'SugarJar::Commands' do
       'http://github.com/org/repo.git',
       # https
       'https://github.com/org/repo.git',
-      # gh
+      # shortname
       'org/repo',
     ].each do |url|
       it "extracts the org from #{url}" do
@@ -127,7 +127,7 @@ describe 'SugarJar::Commands' do
       'http://github.com/org/repo.git',
       # https
       'https://github.com/org/repo.git',
-      # gh
+      # shortname
       'org/repo',
     ].each do |url|
       it "extracts the repo from #{url}" do
@@ -144,12 +144,26 @@ describe 'SugarJar::Commands' do
       'http://github.com/org/repo.git',
       # https
       'https://github.com/org/repo.git',
-      # hub
-      'org/repo',
     ].each do |url|
       it "generates correct URL from #{url}" do
         expect(sj.send(:forked_repo, url, 'test')).
           to eq('git@github.com:test/repo.git')
+      end
+    end
+
+    context 'given short names' do
+      # shortname
+      url = 'org/repo'
+      it 'generates correct URL from shortnames on GH' do
+        expect(sj).to receive(:forge_host).and_return('github.com')
+        expect(sj.send(:forked_repo, url, 'test')).
+          to eq('git@github.com:test/repo.git')
+      end
+
+      it 'generates correct URL from shortnames on GL' do
+        expect(sj).to receive(:forge_host).and_return('gitlab.com')
+        expect(sj.send(:forked_repo, url, 'test')).
+          to eq('git@gitlab.com:test/repo.git')
       end
     end
   end
@@ -168,11 +182,20 @@ describe 'SugarJar::Commands' do
       end
     end
 
-    # gh
-    url = 'org/repo'
-    it "canonicalizes short name #{url}" do
-      expect(sj.send(:canonicalize_repo, url)).
-        to eq('git@github.com:org/repo.git')
+    context 'given short names' do
+      # shortname
+      url = 'org/repo'
+      it "canonicalizes short name #{url} on GH" do
+        expect(sj).to receive(:forge_host).and_return('github.com')
+        expect(sj.send(:canonicalize_repo, url)).
+          to eq('git@github.com:org/repo.git')
+      end
+
+      it "canonicalizes short name #{url} on GH" do
+        expect(sj).to receive(:forge_host).and_return('gitlab.com')
+        expect(sj.send(:canonicalize_repo, url)).
+          to eq('git@gitlab.com:org/repo.git')
+      end
     end
   end
 end


### PR DESCRIPTION
We now fully support gitlab in addition to github, via the `glab` CLI.

In most cases, we will dynamically determine the right forge, except
for during cloning when `--forge-type` is necessary to change the 
default.

A few other changes:

* `--github-host` is now `--forge-host` (though the old command-line
  option works, for now) 
* there is now a `--gitlab-user` (and associated config file option)
* we're better at supporting enterprise GH/GL

Signed-off-by: Phil Dibowitz <phil@ipom.com>
