### PR TITLE
unit tests: mock forge_host

### DIFF
--- a/spec/commands_spec.rb
+++ b/spec/commands_spec.rb
@@ -146,6 +146,7 @@ describe 'SugarJar::Commands' do
       'https://github.com/org/repo.git',
     ].each do |url|
       it "generates correct URL from #{url}" do
+        expect(sj).to receive(:forge_host).and_return('github.com')
         expect(sj.send(:forked_repo, url, 'test')).
           to eq('git@github.com:test/repo.git')
       end


### PR DESCRIPTION
Zeal reported issues with the forked_repo tests. I can't repro it, but
based on the results he's getting, it looks like forge_host is
incorrectly exacracting a host from his origin remote, so mock
it for this test.

Signed-off-by: Phil Dibowitz <phil@ipom.com>
