### PR TITLE
Fix short-circuit for non-forked PRs

### DIFF
--- a/lib/sugarjar/commands/smartpullrequest.rb
+++ b/lib/sugarjar/commands/smartpullrequest.rb
@@ -103,7 +103,9 @@ class SugarJar
           "\tgit remote set-head #{upstream} -a",
         )
       end
-      return if upstream_branch == 'origin'
+
+      # If we don't have an upstream and an origin, we're done
+      return if upstream == 'origin'
 
       origin_branch = main_remote_branch('origin')
       # NOTE: that on GL, forks don't fork any branches by default, even


### PR DESCRIPTION
When checking if all the primary branches match, we have
a short-circuit, but it was checking the wrong thing.

Signed-off-by: Phil Dibowitz <phil@ipom.com>
