### PR TITLE
Fix tab completion with prefixed feature branches

### DIFF
--- a/extras/sugarjar_completion.bash
+++ b/extras/sugarjar_completion.bash
@@ -18,7 +18,7 @@ _sugarjar_completions()
     local prefix=''
     if [ -e "$SJCONFIG" ]; then
         if type yq &>/dev/null; then
-            prefix=$(yq .feature_prefix $SJCONFIG)
+            prefix=$(yq -r .feature_prefix $SJCONFIG)
         else
             # the xargs removes extra spaces
             prefix=$(grep feature_prefix $SJCONFIG | cut -f2 -d: | xargs)


### PR DESCRIPTION
When `yq` is available, we were not running it with `-r`, and thus
the prefix we detected included quotes, so stripping it off didn't work.

This fixes that.

Signed-off-by: Phil Dibowitz <phil@ipom.com>
