### PR TITLE
Add host-specific configs; rework config handling

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,6 +10,9 @@ Layout/LineLength:
 Metrics/BlockNesting:
   Enabled: false
 
+Metrics/ParameterLists:
+  Enabled: false
+
 Naming/FileName:
   Enabled: false
 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,13 @@ destination directory to clone to. It will also pass any other unknown options
 to `git clone` under the hood.
 
 If you don't work with fork-based workflows, you can set `use_forks: false`
-in your config, or pass in `--no-use-forks` to `sj sclone`.
+in your config for the right host:
+
+```yaml
+host_configs:
+  default:
+    use_forks: false
+```
 
 ### Work with stacked branches more easily
 
@@ -347,6 +353,14 @@ e.g. `$USER/`.
 For example, if your prefix was `user/`, then `sj feature foo` would create
 `user/foo`, and `sj co foo` would switch to `user/foo`.
 
+Here's an example:
+
+```yaml
+host_configs:
+  default:
+    feature_prefix: "jsmith/"
+```
+
 ### Smartlog
 
 Smartlog will show you a tree diagram of your branches! Simply run `sj
@@ -454,24 +468,18 @@ prone, so this setting will automatically set this up for each developer.
 Like `gh` and `glab`, SugarJar supports Enterprise versions of GitHub and
 GitLab. In fact, we provide extra features just for it.
 
-In most cases, when using `sj smartclone`, pass in `--forge-host`, and
-that's about all you need, everything else should be handlded automagically.
-
-However, you can set `forge_host` in your global or user config, but since most
-users will also have a few opensource repos, you can override it in the
-Repository Config as well.
+By default, SugarJar will pick up the appropriate information from the repo
+itself, so the only real interesting part is `smartclone`. In most cases,
+SugarJar will automatically determine the proper forge-host based on the URL
+you pass in. However, if you use short names ("repo/org" or
+"company/repo/org"), then you can either pass in `--default-forge-host`, or, if
+you want to always default to a given host, you can set a top-level
+`default_forge_host` in your SugarJar config:
 
 So, for example you might have:
 
 ```yaml
-forge_host: gh.sample.com
-```
-
-In your `~/.config/sugarjar/config.yaml`, but if the `.sugarjar.yaml` in your
-repo has:
-
-```yaml
-forge_host: github.com
+default_forge_host: gh.sample.com
 ```
 
 ## FAQ

--- a/bin/sj
+++ b/bin/sj
@@ -31,39 +31,21 @@ parser = OptionParser.new do |opts|
   opts.separator ''
   opts.separator 'OPTIONS:'
 
-  opts.on('--feature-prefix', 'Prefix to use for feature branches') do |prefix|
-    options['feature_prefix'] = prefix
-  end
-
   opts.on(
-    '--forge-host HOST',
-    '--github-host HOST',
+    '--default-forge-host HOST',
     'The host of your forge (github, gitlab, etc.). Generally only needed' +
     ' when cloning (smartclone), as we can usually figure out from within' +
-    ' a cloned repo. Currently accepts --github-host for backwards' +
-    ' compatibility.',
+    ' a cloned repo.',
   ) do |host|
-    options['forge_host'] = host
-  end
-
-  opts.on('--forge-type TYPE', 'Forge type: github, gitlab') do |type|
-    options['forge_type'] = type
+    options['default_forge_host'] = host
   end
 
   opts.on(
-    '--github-user USER',
-    'User for github repos, unless specified in the repoconfig.' +
-    ' Defaults to your local username',
-  ) do |user|
-    options['github_user'] = user
-  end
-
-  opts.on(
-    '--gitlab-user USER',
-    'User for gitlab repos, unless specified in the repoconfig.' +
-    ' Defaults to your local username',
-  ) do |user|
-    options['gitlab_user'] = user
+    '--force-forge-type TYPE',
+    'GENERALLY NOT NEEDED. In case SJ cannot detect the type of a forge ' +
+    'from the hostname during smartclone. Forge type: github, gitlab',
+  ) do |type|
+    options['force_forge_type'] = type
   end
 
   opts.on('-h', '--help', 'Print this help message') do
@@ -101,14 +83,6 @@ parser = OptionParser.new do |opts|
     'commit if we are using "gh". [default: true]',
   ) do |autofill|
     options['pr_autofill'] = autofill
-  end
-
-  opts.on(
-    '--[no-]use-forks',
-    'Create (add a remote for) forks, when the organization does not match ' +
-    'the user. [default: true]',
-  ) do |val|
-    options['use_forks'] = val
   end
 
   opts.on(

--- a/examples/sample_config.yaml
+++ b/examples/sample_config.yaml
@@ -23,8 +23,14 @@ pr_autostack: true
 # list
 ignore_deprecated_options: [ 'gh_cli' ]
 
-# User to use when cloning new github repos
-github_user: c00ldude
-
-# User to use when cloning new gitlab repos
-gitlab_user: c00ldude
+host_configs:
+  default:
+    use_forks: true
+  github.com:
+    user: c00ldude
+  gitlab.com:
+    user: thisc00ldude
+  gitlab.company.com:
+    user: tsmith
+    use_forks: false
+    feature_prefix: "tsmith/"

--- a/examples/sample_repoconfig.yaml
+++ b/examples/sample_repoconfig.yaml
@@ -74,20 +74,3 @@ on_push: [lint] # or [lint, unit]
 # template configured.
 
 commit_template: .git_commit_template.txt
-
-# `github_user` is the user to use when talking to GitHub. Overrides any such
-# setting in the regular SugarJar config. Most useful when in the
-# `include_from` file.
-
-github_user: myuser
-
-# `gitlab_user` is the user to use when talking to GitLab. Overrides any such
-# setting in the regular SugarJar config. Most useful when in the
-# `include_from` file.
-
-gitlab_user: myuser
-
-# `forge_host` is the GitHub/GitLab host to use when talking to hosted versions
-# of these services.
-
-forge_host: github.sample.com

--- a/lib/sugarjar/commands.rb
+++ b/lib/sugarjar/commands.rb
@@ -25,39 +25,21 @@ class SugarJar
 
     def initialize(options)
       SugarJar::Log.debug("Commands.initialize options: #{options}")
-      @ignore_dirty = options['ignore_dirty']
-      @ignore_prerun_failure = options['ignore_prerun_failure']
+      @config = options
       @repo_config = SugarJar::RepoConfig.config
       SugarJar::Log.debug("Repoconfig: #{@repo_config}")
-      @color = options['color']
-      @pr_autofill = options['pr_autofill']
-      @pr_autostack = options['pr_autostack']
-      @feature_prefix = options['feature_prefix']
-      @use_forks = options['use_forks']
-      @fork_name = options['fork_name']
+
       @checks = {}
       @main_branch = nil
       @main_remote_branches = {}
-      # This is CONFIGURED host, which may be null, as opposed
-      # to the method forge_host which will always return something
-      @_forge_host = @repo_config['forge_host'] || options['forge_host']
-      @repo_forge = @repo_config['forge_type'] || options['forge_type'] ||
-                    _determine_forge_type
 
-      unless @repo_forge.nil?
-        cmd = _forge_cmd
-        unless SugarJar::Util.which_nofail(cmd)
-          die("No '#{cmd}' found, please install it'")
-        end
-      end
+      @host_config = gen_host_config
 
-      user_option = "#{@repo_forge}_user"
-      @forge_user = @repo_config[user_option] || options[user_option]
-
-      # Tell the cli where to talk to, if not default
-      if @_forge_host
-        ENV['GH_HOST'] = @_forge_host
-        ENV['GL_HOST'] = @_forge_host
+      if @host_config['forge_type'] && !forge_cli_avail?
+        SugarJar::Log.error(
+          "Forge CLI #{_forge_cmd} is unavailable, please install",
+        )
+        exit 1
       end
 
       return if options['no_change']
@@ -67,9 +49,28 @@ class SugarJar
 
     private
 
+    def gen_host_config(host = nil)
+      host ||= _determine_forge_host
+      _config_for_host(host) || {}
+    end
+
+    def _config_for_host(host)
+      SugarJar::Log.debug("config_for_host called for #{host}")
+      r = @config.dig('host_configs', 'default').dup || {}
+      r.merge!(@config.dig('host_configs', host) || {})
+      r['forge_host'] = host
+      # if people specified a forge_type, honor it
+      r['forge_type'] ||= _determine_forge_type(host)
+      SugarJar::Log.debug("Determined config for host: #{r}")
+      r
+    end
+
     def forked_repo(repo, username)
+      host = @host_config['forge_host'] || extract_host(repo)
       repo = extract_repo(repo)
-      "git@#{forge_host}:#{username}/#{repo}.git"
+      raise 'Cannot determine host' unless host
+
+      "git@#{host}:#{username}/#{repo}.git"
     end
 
     # gh utils will default to https, but we should always default to SSH
@@ -78,23 +79,24 @@ class SugarJar
       # if they fully-qualified it, we're good
       return repo if repo.start_with?('http', 'git@')
 
+      host = @host_config['forge_host'] || extract_host(repo)
       # otherwise, it's a shortname
-      cr = "git@#{forge_host}:#{repo}.git"
+      cr = "git@#{host}:#{repo}.git"
       SugarJar::Log.debug("canonicalized #{repo} to #{cr}")
       cr
     end
 
-    def forge_host
-      # if one is specifically configured, use that
-      return @_forge_host if @_forge_host
+    def _determine_forge_host
+      # DO NOT USE in the general case - ONLY for filling in @host_config
+      # (doesn't consult host_config). Use @host_config['forge_host']
+      # in general.
 
-      # otherwise, if we're in a repo, use the hostname of the remote
+      # if we're in a repo, use the hostname of the remote
       if SugarJar::Util.in_repo?
         url = remote_url_map.values.first
         return extract_host(url)
       end
-
-      @repo_forge == 'gitlab' ? 'gitlab.com' : 'github.com'
+      @config['default_forge_host']
     end
 
     def repo_shortname(repo)
@@ -156,7 +158,7 @@ class SugarJar
     def dirty_check!
       return unless dirty?
 
-      if @ignore_dirty
+      if @config['ignore_dirty']
         SugarJar::Log.warn(
           'Your repo is dirty, but --ignore-dirty was specified, so ' +
           'carrying on anyway.',
@@ -302,7 +304,7 @@ class SugarJar
     end
 
     def color(string, *colors)
-      if @color
+      if @config['color']
         pastel.decorate(string, *colors)
       else
         string
@@ -321,12 +323,12 @@ class SugarJar
     end
 
     def fprefix(name)
-      return name unless @feature_prefix
+      return name unless @host_config['feature_prefix']
 
-      return name if name.start_with?(@feature_prefix)
+      return name if name.start_with?(@host_config['feature_prefix'])
       return name if all_local_branches.include?(name)
 
-      newname = "#{@feature_prefix}#{name}"
+      newname = "#{@host_config['feature_prefix']}#{name}"
       SugarJar::Log.debug(
         "Munging feature name: #{name} -> #{newname} due to feature prefix",
       )
@@ -412,29 +414,43 @@ class SugarJar
     end
 
     def git(*)
-      SugarJar::Util.git(*, :color => @color)
+      SugarJar::Util.git(*, :color => @config['color'])
     end
 
     def git_nofail(*)
-      SugarJar::Util.git_nofail(*, :color => @color)
+      SugarJar::Util.git_nofail(*, :color => @config['color'])
     end
 
-    def _determine_forge_type
+    def _determine_forge_type(host = nil)
+      if @config['force_forge_type']
+        SugarJar::Log.warn(
+          'Using forge_type from --force-forge-type, not detecting forge' +
+          ' type. This should not be necessary, it is not recommended you' +
+          ' set this.',
+        )
+        return @config['force_forge_type']
+      end
+
+      if host
+        return host.include?('gitlab') ? 'gitlab' : 'github'
+      end
+
       if SugarJar::Util.in_repo?
         gl = remote_url_map.values.any? { |x| x.include?('gitlab') }
         return gl ? 'gitlab' : 'github'
       end
 
-      # if all else fails, guess GH
-      'github'
+      # in smartclone mode, when creating the object, we will in fact
+      # be unable to determine this, that's expacted
+      SugarJar::Log.debug('Unable to determine forge_type!')
     end
 
     def _forge_cmd
-      @repo_forge == 'gitlab' ? 'glab' : 'gh'
+      @host_config['forge_type'] == 'gitlab' ? 'glab' : 'gh'
     end
 
     def forge(*)
-      if @repo_forge == 'gitlab'
+      if @host_config['forge_type'] == 'gitlab'
         SugarJar::Util.glcli(*)
       else
         SugarJar::Util.ghcli(*)
@@ -442,7 +458,7 @@ class SugarJar
     end
 
     def forge_nofail(*)
-      if @repo_forge == 'gitlab'
+      if @host_config['forge_type'] == 'gitlab'
         SugarJar::Util.glcli_nofail(*)
       else
         SugarJar::Util.ghcli_nofail(*)

--- a/lib/sugarjar/commands/checks.rb
+++ b/lib/sugarjar/commands/checks.rb
@@ -7,7 +7,7 @@ class SugarJar
 
       # does not use dirty_check! as we want a custom message
       if dirty?
-        if @ignore_dirty
+        if @config['ignore_dirty']
           SugarJar::Log.warn(
             'Your repo is dirty, but --ignore-dirty was specified, so ' +
             'carrying on anyway. If the linter autocorrects, the displayed ' +

--- a/lib/sugarjar/commands/push.rb
+++ b/lib/sugarjar/commands/push.rb
@@ -23,7 +23,7 @@ class SugarJar
       dirty_check!
 
       unless run_prepush
-        if @ignore_prerun_failure
+        if @config['ignore_prerun_failure']
           SugarJar::Log.warn(
             'Pre-push checks failed, but --ignore-prerun-failure was ' +
             'specified, so carrying on anyway',

--- a/lib/sugarjar/commands/smartclone.rb
+++ b/lib/sugarjar/commands/smartclone.rb
@@ -3,13 +3,26 @@ class SugarJar
     def smartclone(repo, *args)
       org = extract_org(repo)
       reponame = extract_repo(repo)
+      host = extract_host(repo) || @config['default_forge_host']
+      unless host
+        raise 'Failed to determine host. Please specify --default-forge-host,' +
+              ' and file a bug.'
+      end
+      @host_config = gen_host_config(host)
+      raise 'Failed to determine forge_type' unless @host_config['forge_type']
+
+      # set env vars of the host, just for completeness
+      # since it's short-lived we just set both vars
+      ENV['GH_HOST'] = host
+      ENV['GL_HOST'] = host
+
       dir = if args.length.positive? && !args.first.start_with?('-')
               args.shift
             else
               reponame
             end
 
-      forkname = @fork_name || reponame
+      forkname = @config['fork_name'] || reponame
 
       SugarJar::Log.info("Cloning #{reponame}...")
 
@@ -19,8 +32,8 @@ class SugarJar
       #
       # Unless the repo is in our own org and cannot be forked, then it
       # will fail.
-      if @use_forks && @forge_user != org
-        if @repo_forge == 'gitlab'
+      if @host_config['use_forks'] && @host_config['user'] != org
+        if @host_config['forge_type'] == 'gitlab'
           _gitlab_clone(org, repo, dir, forkname, *args)
         else
           forge(
@@ -79,7 +92,7 @@ class SugarJar
         # and then configure remotes properly
         git('remote', 'rename', 'origin', 'upstream')
 
-        fork_url = forked_repo(repo, @forge_user)
+        fork_url = forked_repo(repo, @host_config['user'])
         git('remote', 'add', 'origin', fork_url)
       end
     end

--- a/lib/sugarjar/commands/smartpullrequest.rb
+++ b/lib/sugarjar/commands/smartpullrequest.rb
@@ -19,7 +19,7 @@ class SugarJar
 
       curr = current_branch
       base = tracked_branch
-      if @pr_autofill
+      if @config['pr_autofill']
         SugarJar::Log.info('Autofilling in PR from commit message')
         num_commits = git(
           'rev-list', '--count', curr, "^#{base}"
@@ -41,14 +41,14 @@ class SugarJar
               ' PR is rebased.',
             )
           # nil is prompt, true is always, false is never
-          elsif @pr_autostack.nil?
+          elsif @config['pr_autostack'].nil?
             $stdout.print(
               'It looks like this is a subfeature, would you like to base ' +
               "this PR on #{base}? [y/n] ",
             )
             ans = $stdin.gets.strip
             args.unshift('--base', base) if %w{Y y}.include?(ans)
-          elsif @pr_autostack
+          elsif @config['pr_autostack']
             args.unshift('--base', base)
           end
         elsif base.include?('/') && base != most_main
@@ -60,7 +60,7 @@ class SugarJar
 
       # <org>:<branch> is the GH API syntax for:
       #   look for a branch of name <branch>, from a fork in owner <org>
-      if @repo_forge == 'github'
+      if @host_config['forge_type'] == 'github'
         # On GitHub, the head is the org and the *BRANCH* name to use as
         # the head branch...
         args.unshift('--head', "#{push_org}:#{curr}")
@@ -87,7 +87,7 @@ class SugarJar
     private
 
     def _pr_cmd
-      @repo_forge == 'gitlab' ? 'mr' : 'pr'
+      @host_config['forge_type'] == 'gitlab' ? 'mr' : 'pr'
     end
 
     def assert_common_main_branch!

--- a/lib/sugarjar/config.rb
+++ b/lib/sugarjar/config.rb
@@ -1,25 +1,52 @@
 require 'yaml'
 require_relative 'log'
+require 'deep_merge'
 
 class SugarJar
   # This parses SugarJar configs (not to be confused with repoconfigs).
   # This is stuff like log level, github-user, etc.
   class Config
     DEFAULTS = {
-      'github_user' => ENV.fetch('USER'),
-      'gitlab_user' => ENV.fetch('USER'),
+      'default_forge_host' => nil,
       'pr_autofill' => true,
       'pr_autostack' => nil,
       'color' => true,
-      'use_forks' => true,
       'ignore_deprecated_options' => [],
+      'host_configs' => {
+        'default' => {
+          'user' => ENV.fetch('USER'),
+          'use_forks' => true,
+        },
+      },
+    }.freeze
+
+    # things we have a command-line option for, but doesn't make sense
+    # in a config file.
+    EXTRA_CONFIGS = %w{fork_name force_forge_type}.freeze
+
+    TOP_LEVEL_CONFIGS = (DEFAULTS.keys + EXTRA_CONFIGS).freeze
+
+    DEPRECATED_OPTIONS = %w{
+      fallthru
+      gh_cli
+      github_user
+      gitlab_user
+      github_host
+      gitlab_host
     }.freeze
 
     def self._find_ordered_files
+      real_files = []
       [
-        '/etc/sugarjar/config.yaml',
-        "#{Dir.home}/.config/sugarjar/config.yaml",
-      ].select { |f| File.exist?(f) }
+        '/etc/sugarjar',
+        "#{Dir.home}/.config/sugarjar",
+      ].each do |dir|
+        %w{yaml yml}.each do |ext|
+          f = File.join(dir, "config.#{ext}")
+          real_files << f if File.exist?(f)
+        end
+      end
+      real_files
     end
 
     def self.config
@@ -28,13 +55,11 @@ class SugarJar
       _find_ordered_files.each do |f|
         SugarJar::Log.debug("Loading config #{f}")
         data = YAML.safe_load_file(f)
+        next unless data
+
         warn_on_deprecated_configs(data, f)
-        if data['github_host']
-          data['forge_host'] = data['github_host'] if data['forge_host'].nil?
-          data.delete('github_host')
-        end
-        # an empty file is a `nil` which you can't merge
-        c.merge!(YAML.safe_load_file(f)) if data
+        data = data.slice(*TOP_LEVEL_CONFIGS)
+        c.deep_merge!(data)
         SugarJar::Log.debug("Modified config: #{c}")
       end
       c
@@ -42,7 +67,7 @@ class SugarJar
 
     def self.warn_on_deprecated_configs(data, fname)
       ignore_deprecated_options = data['ignore_deprecated_options'] || []
-      %w{fallthru gh_cli}.each do |opt|
+      DEPRECATED_OPTIONS.each do |opt|
         next unless data.key?(opt)
 
         if ignore_deprecated_options.include?(opt)
@@ -55,29 +80,6 @@ class SugarJar
         SugarJar::Log.warn(
           "#{fname}: contains deprecated option `#{opt}`. You can " +
           'suppress this warning with `ignore_deprecated_options`.',
-        )
-      end
-
-      # github_host has special handling
-      return unless data['github_host']
-
-      if ignore_deprecated_options.include?('github_host')
-        SugarJar::Log.debug(
-          "#{fname}: Deprecated option `github_host` found, but not " +
-          'warning due to `ignore_deprecated_options` in that file.',
-        )
-      elsif data.key?('forge_host')
-        SugarJar::Log.warn(
-          "#{fname}: Deprecated option `github_host` found. " +
-          'Ignoring in favor of newer `force_host` option. You can ' +
-          'suppress this warning with `ignore_deprecated_options`.',
-        )
-      else
-        SugarJar::Log.warn(
-          "#{fname}: Deprecated option `github_host` found. " +
-          'Treating it as if it was `forge_host` for now. Please update ' +
-          'your config file to use this new option. You can suppress ' +
-          'this warning with `ignore_deprecated_options`.',
         )
       end
     end

--- a/spec/commands/branch_spec.rb
+++ b/spec/commands/branch_spec.rb
@@ -17,7 +17,14 @@ describe 'SugarJar::Commands' do
 
     it 'attempts to checkout the branch with feature prefix, if it exists' do
       sj = SugarJar::Commands.new(
-        { 'no_change' => true, 'feature_prefix' => 'fp/' },
+        {
+          'no_change' => true,
+          'host_configs' => {
+            'default' => {
+              'feature_prefix' => 'fp/',
+            },
+          },
+        },
       )
       branch = 'foo'
       allow(sj).to receive(:assert_in_repo!)
@@ -32,7 +39,14 @@ describe 'SugarJar::Commands' do
 
     it 'will checkout non-prefixed branch if prefixed branch does not exist' do
       sj = SugarJar::Commands.new(
-        { 'no_change' => true, 'feature_prefix' => 'fp/' },
+        {
+          'no_change' => true,
+          'host_configs' => {
+            'default' => {
+              'feature_prefix' => 'fp/',
+            },
+          },
+        },
       )
       branch = 'foo'
       allow(sj).to receive(:assert_in_repo!)

--- a/spec/commands/smartclone_spec.rb
+++ b/spec/commands/smartclone_spec.rb
@@ -9,20 +9,22 @@ describe 'SugarJar::Commands' do
       SugarJar::Commands.new(opts)
     end
 
+    before do
+      allow(SugarJar::Util).to receive(:in_repo?).and_return(false)
+    end
+
     context 'repo is in our own org' do
       let(:repo) do
         'git@github.com:myuser/repo.git'
       end
 
       it 'uses git' do
-        sj.instance_variable_set(:@forge_user, opts['github_user'])
         expect(sj).to_not receive(:forge)
         expect(sj).to receive(:git).with('clone', repo, 'repo')
         sj.smartclone(repo)
       end
 
       it 'passes additional arguments to git' do
-        sj.instance_variable_set(:@forge_user, opts['github_user'])
         expect(sj).to_not receive(:forge)
         expect(sj).to receive(:git).with('clone', repo, 'somedir',
                                          '--something')
@@ -35,9 +37,14 @@ describe 'SugarJar::Commands' do
         let(:opts) do
           {
             'no_change' => true,
-            'github_user' => 'myuser',
-            'forge_type' => 'github',
-            'use_forks' => true,
+            'host_configs' => {
+              'default' => {
+                'use_forks' => true,
+              },
+              'github.com' => {
+                'user' => 'myuser',
+              },
+            },
           }
         end
 
@@ -78,7 +85,6 @@ describe 'SugarJar::Commands' do
           end
 
           it 'bypasses fork' do
-            sj.instance_variable_set(:@forge_user, opts['github_user'])
             expect(sj).to_not receive(:forge)
             expect(sj).to receive(:git).with('clone', repo, 'repo')
             sj.smartclone(repo)
@@ -90,10 +96,20 @@ describe 'SugarJar::Commands' do
         let(:opts) do
           {
             'no_change' => true,
-            'github_user' => 'myuser',
-            'forge_type' => 'gitlab',
-            'use_forks' => true,
+            'host_configs' => {
+              'default' => {
+                'use_forks' => true,
+              },
+              'gitlab.com' => {
+                'user' => 'myuser',
+              },
+            },
           }
+        end
+
+        before do
+          expect(SugarJar::Util).to receive(:in_repo?).at_least(:once).
+            and_return(false)
         end
 
         let(:repo) do
@@ -114,9 +130,6 @@ describe 'SugarJar::Commands' do
           expect(Dir).to receive(:chdir).with('repo').exactly(2).times.and_yield
           expect(sj).to receive(:git).with('remote', 'rename', 'origin',
                                            'upstream')
-          expect(sj).to receive(:forked_repo).and_return(
-            'git@gitlab.com:myuser/repo.git',
-          )
           expect(sj).to receive(:git).with(
             'remote', 'add', 'origin', 'git@gitlab.com:myuser/repo.git'
           )
@@ -136,9 +149,6 @@ describe 'SugarJar::Commands' do
           expect(Dir).to receive(:chdir).with('repo').exactly(2).times.and_yield
           expect(sj).to receive(:git).with('remote', 'rename', 'origin',
                                            'upstream')
-          expect(sj).to receive(:forked_repo).and_return(
-            'git@gitlab.com:myuser/repo.git',
-          )
           expect(sj).to receive(:git).with(
             'remote', 'add', 'origin', 'git@gitlab.com:myuser/repo.git'
           )
@@ -159,9 +169,6 @@ describe 'SugarJar::Commands' do
             times.and_yield
           expect(sj).to receive(:git).with('remote', 'rename', 'origin',
                                            'upstream')
-          expect(sj).to receive(:forked_repo).and_return(
-            'git@gitlab.com:myuser/repo.git',
-          )
           expect(sj).to receive(:git).with(
             'remote', 'add', 'origin', 'git@gitlab.com:myuser/repo.git'
           )
@@ -181,7 +188,6 @@ describe 'SugarJar::Commands' do
           end
 
           it 'bypasses fork' do
-            sj.instance_variable_set(:@forge_user, opts['github_user'])
             expect(sj).to_not receive(:forge)
             expect(sj).to receive(:git).with('clone', repo, 'repo')
             sj.smartclone(repo)

--- a/spec/commands_spec.rb
+++ b/spec/commands_spec.rb
@@ -6,6 +6,103 @@ describe 'SugarJar::Commands' do
     SugarJar::Commands.new({ 'no_change' => true })
   end
 
+  context '#_config_for_host' do
+    let(:base_config) do
+      {
+        'host_configs' => {
+          'default' => {
+            'use_forks' => true,
+          },
+          'github.com' => {
+            'user' => 'ghuser',
+          },
+          'gitlab.com' => {
+            'user' => 'gluser',
+          },
+        },
+      }
+    end
+
+    it 'provides defaults when no overrides specified' do
+      sj = SugarJar::Commands.new(base_config)
+      c = sj.send(:_config_for_host, 'github.com')
+      {
+        'forge_type' => 'github',
+        'forge_host' => 'github.com',
+        'user' => 'ghuser',
+        'use_forks' => true,
+      }.each do |k, v|
+        expect(c[k]).to eq(v)
+      end
+    end
+
+    it 'uses overrides when they are available' do
+      config = base_config.dup
+      config['host_configs']['github.com'] = {
+        'user' => 'special_user',
+        'use_forks' => false,
+      }
+      sj = SugarJar::Commands.new(config)
+      c = sj.send(:_config_for_host, 'github.com')
+      {
+        'forge_type' => 'github',
+        'user' => 'special_user',
+        'use_forks' => false,
+      }.each do |k, v|
+        expect(c[k]).to eq(v)
+      end
+    end
+
+    it 'handles partial overrides' do
+      config = base_config.dup
+      config['host_configs']['github.com']['use_forks'] = false
+      sj = SugarJar::Commands.new(config)
+      c = sj.send(:_config_for_host, 'github.com')
+      {
+        'forge_type' => 'github',
+        'user' => 'ghuser',
+        'use_forks' => false,
+      }.each do |k, v|
+        expect(c[k]).to eq(v)
+      end
+    end
+
+    it 'picks the correct override from many' do
+      config = base_config.dup
+      {
+        'github.com' => {
+          'user' => 'one',
+          'use_forks' => false,
+        },
+        'mycompany.github.com' => {
+          'user' => 'two',
+          'use_forks' => false,
+        },
+        'something.gitlab.com' => {
+          'user' => 'three',
+        },
+        'gitlab.com' => {
+          'user' => 'four',
+        },
+      }.each do |host, cfg|
+        config['host_configs'][host] = cfg
+      end
+      # bypass the git repo we're running in or it will taint the @config
+      expect(SugarJar::Util).to receive(:in_repo?).at_least(
+        :once,
+      ).times.and_return(false)
+      sj = SugarJar::Commands.new(config)
+      {
+        'github.com' => 'one',
+        'mycompany.github.com' => 'two',
+        'something.gitlab.com' => 'three',
+        'gitlab.com' => 'four',
+      }.each do |host, answer|
+        expect(sj.send(:_config_for_host, host)['user']).to eq(answer)
+      end
+    end
+  end
+
   context '#set_commit_template' do
     it 'Does nothing if not in repo' do
       expect(SugarJar::RepoConfig).to receive(:config).and_return(
@@ -90,7 +187,12 @@ describe 'SugarJar::Commands' do
   context '#fprefix' do
     it 'Adds prefixes when needed' do
       sj = SugarJar::Commands.new(
-        { 'no_change' => true, 'feature_prefix' => 'someuser/' },
+        {
+          'no_change' => true,
+          'host_configs' => {
+            'default' => { 'feature_prefix' => 'someuser/' },
+          },
+        },
       )
       expect(sj).to receive(:all_local_branches).and_return(['/nonexistent'])
       expect(sj.send(:fprefix, 'test')).to eq('someuser/test')
@@ -182,7 +284,6 @@ describe 'SugarJar::Commands' do
       'https://github.com/org/repo.git',
     ].each do |url|
       it "generates correct URL from #{url}" do
-        expect(sj).to receive(:forge_host).and_return('github.com')
         expect(sj.send(:forked_repo, url, 'test')).
           to eq('git@github.com:test/repo.git')
       end
@@ -191,14 +292,25 @@ describe 'SugarJar::Commands' do
     context 'given short names' do
       # shortname
       url = 'org/repo'
+
       it 'generates correct URL from shortnames on GH' do
-        expect(sj).to receive(:forge_host).and_return('github.com')
+        expect(SugarJar::Util).to receive(:in_repo?).at_least(
+          :once,
+        ).times.and_return(false)
+        sj = SugarJar::Commands.new(
+          { 'no_change' => true, 'default_forge_host' => 'github.com' },
+        )
         expect(sj.send(:forked_repo, url, 'test')).
           to eq('git@github.com:test/repo.git')
       end
 
       it 'generates correct URL from shortnames on GL' do
-        expect(sj).to receive(:forge_host).and_return('gitlab.com')
+        expect(SugarJar::Util).to receive(:in_repo?).at_least(
+          :once,
+        ).times.and_return(false)
+        sj = SugarJar::Commands.new(
+          { 'no_change' => true, 'default_forge_host' => 'gitlab.com' },
+        )
         expect(sj.send(:forked_repo, url, 'test')).
           to eq('git@gitlab.com:test/repo.git')
       end
@@ -223,13 +335,23 @@ describe 'SugarJar::Commands' do
       # shortname
       url = 'org/repo'
       it "canonicalizes short name #{url} on GH" do
-        expect(sj).to receive(:forge_host).and_return('github.com')
+        expect(SugarJar::Util).to receive(:in_repo?).at_least(
+          :once,
+        ).times.and_return(false)
+        sj = SugarJar::Commands.new(
+          { 'no_change' => true, 'default_forge_host' => 'github.com' },
+        )
         expect(sj.send(:canonicalize_repo, url)).
           to eq('git@github.com:org/repo.git')
       end
 
       it "canonicalizes short name #{url} on GH" do
-        expect(sj).to receive(:forge_host).and_return('gitlab.com')
+        expect(SugarJar::Util).to receive(:in_repo?).at_least(
+          :once,
+        ).times.and_return(false)
+        sj = SugarJar::Commands.new(
+          { 'no_change' => true, 'default_forge_host' => 'gitlab.com' },
+        )
         expect(sj.send(:canonicalize_repo, url)).
           to eq('git@gitlab.com:org/repo.git')
       end


### PR DESCRIPTION
This PR dramatically reworks config handling internally in order to
enable the idea of `host_override` configs.

If you only ever deal with github and gitlab, the config is fine, but
if you deal with 2 or 3 instances of either, the config is not nearly
expressive enough.

This adds a new `host_overrides` config section which will be merged
into the config when dealing with repos at that host.
