### PR TITLE
Multi-forge fixes

### DIFF
--- a/lib/sugarjar/commands.rb
+++ b/lib/sugarjar/commands.rb
@@ -34,11 +34,14 @@ class SugarJar
       @checks = {}
       @main_branch = nil
       @main_remote_branches = {}
+      @host_config = nil
 
-      @host_config = gen_host_config
-      if @host_config['forge_type']
-        # initialize instance var here so checks run...
-        forge
+      if SugarJar::Git.in_repo?
+        @host_config = gen_host_config
+        if @host_config['forge_type']
+          # initialize instance var here so checks run...
+          forge
+        end
       end
 
       return if options['no_change']
@@ -54,7 +57,9 @@ class SugarJar
         raise 'Attempted to create Forge object before forge-type known!'
       end
 
-      @forge = SugarJar::Forge.new(@host_config['forge_type'])
+      @forge = SugarJar::Forge.new(
+        @host_config['forge_type'], @host_config['forge_host']
+      )
     end
 
     def gen_host_config(host = nil)
@@ -78,9 +83,11 @@ class SugarJar
     end
 
     def forked_repo(repo, username)
-      host = @host_config['forge_host'] || extract_host(repo)
-      repo = extract_repo(repo)
+      host = @host_config&.dig('forge_host') || extract_host(repo) ||
+             @config['default_forge_host']
       raise 'Cannot determine host' unless host
+
+      repo = extract_repo(repo)
 
       "git@#{host}:#{username}/#{repo}.git"
     end
@@ -89,9 +96,10 @@ class SugarJar
     # unless otherwise specified since https will cause prompting.
     def canonicalize_repo(repo)
       # if they fully-qualified it, we're good
-      return repo if repo.start_with?('http', 'git@')
+      return repo if repo.start_with?('http', 'git@', 'ssh://')
 
-      host = @host_config['forge_host'] || extract_host(repo)
+      host = @host_config&.dig('forge_host') || extract_host(repo) ||
+             @config['default_forge_host']
       # otherwise, it's a shortname
       cr = "git@#{host}:#{repo}.git"
       SugarJar::Log.debug("canonicalized #{repo} to #{cr}")
@@ -188,7 +196,11 @@ class SugarJar
     end
 
     def determine_main_branch(branches)
-      branches.include?('master') ? 'master' : 'main'
+      if branches.include?('main')
+        'main'
+      elsif branches.include?('master')
+        'master'
+      end
     end
 
     def main_branch
@@ -379,6 +391,8 @@ class SugarJar
     def extract_host(repo)
       if repo.start_with?('git@')
         repo.split(':').first.split('@').last
+      elsif repo.start_with?('ssh://')
+        repo.split('/')[2].split('@').last
       elsif repo.start_with?('http')
         repo.split('/')[2]
       end
@@ -440,7 +454,14 @@ class SugarJar
 
     def _determine_forge_type(host = nil)
       if host
-        return host.include?('gitlab') ? 'gitlab' : 'github'
+        case host
+        when /gitlab/
+          return 'gitlab'
+        when /github/
+          return 'github'
+        when /forgejo|codeberg/
+          return 'forgejo'
+        end
       end
 
       if SugarJar::Git.in_repo?

--- a/lib/sugarjar/commands/smartclone.rb
+++ b/lib/sugarjar/commands/smartclone.rb
@@ -11,7 +11,10 @@ class SugarJar
       @host_config = gen_host_config(host)
       raise 'Failed to determine forge_type' unless @host_config['forge_type']
 
-      # force object creation for error checking
+      # force object recreation - the initial creation would not
+      # have had the right data. Plus, we want it to check for the
+      # right cli
+      @forge = nil
       forge
 
       # set env vars of the host, just for completeness
@@ -87,7 +90,8 @@ class SugarJar
       # collision. There's no way to tell, so we assume it means we've
       # already forked.
       if s.error?
-        if forge.type == 'gitlab' && s.stderr.include?(' 409 ')
+        if %w{gitlab forgejo}.include?(forge.type) &&
+           s.stderr.include?(' 409 ')
           SugarJar::Log.debug('Forking failed, probably already forked')
         else
           s.error!

--- a/lib/sugarjar/forge.rb
+++ b/lib/sugarjar/forge.rb
@@ -12,8 +12,9 @@ class SugarJar
       'forgejo' => 'fj',
     }.freeze
 
-    def initialize(type)
+    def initialize(type, host)
       @type = type
+      @host = host
       assert_cli_avail!
     end
 
@@ -38,8 +39,9 @@ class SugarJar
       s
     end
 
-    def run_with_system(*)
-      system(cmd, *)
+    def run_with_system(*args)
+      SugarJar::Log.trace("Running: #{cmd} #{args.join(' ')}")
+      system(cmd, *args)
     end
 
     private
@@ -48,18 +50,34 @@ class SugarJar
       SugarJar::Log.trace("Running: #{cli} #{args.join(' ')}")
       bin = SugarJar::Util.which_nofail(cli)
       s = Mixlib::ShellOut.new([bin] + args).run_command
-      if s.error? && s.stderr.include?("#{cli} auth")
+      if s.error? && ["#{cli} auth", 'Unauthorized'].intersect?(s.stderr)
         SugarJar::Log.info(
-          'glab was run but no gitlab token exists. Will run ' +
-          '"glab auth login" to force\ngh to authenticate...',
+          "#{cli} was run but no gitlab token exists. Will run " +
+          "'#{cli} auth login' to force\n#{cli} to authenticate...",
         )
-        unless system(bin, 'auth', 'login', '-p', 'ssh')
+        args = if cli == 'fj'
+                 [bin, '-H', @host, 'auth', 'login']
+               else
+                 [bin, 'auth', 'login', '-p', 'ssh']
+               end
+        unless system(*args)
           SugarJar::Log.fatal(
-            'That failed, I will bail out. Hub needs to get a github ' +
-            'token. Try running "gh auth login" (will list info about ' +
+            "That failed, I will bail out. #{cli} needs to get a " +
+            "token. Try running '#{cli} auth login' (will list info about " +
             'your account) and try this again when that works.',
           )
           exit(1)
+        end
+        if cli == 'fj'
+          fj = Mixlib::ShellOut.new([bin, 'auth', 'list']).run_command
+          unless fj.stdout.include?(@host)
+            SugarJar::Log.fatal(
+              'Logging in for you failed - this usually means you need to ' +
+              'create a token manually - the instructions should have been ' +
+              'printed above. Setup the token and then try again.',
+            )
+            exit(1)
+          end
         end
       end
       s


### PR DESCRIPTION
* Don't try to determine host/type before we're ready
* Cache the host in the forge object so we can auth with it if we need
  to
* Handle ssh:// format URLs (from forgejo)
* Be more explicit about main-branch determination
* Detect 'codeberg' and 'forgejo' as forgejo-ish hostnames
* Handle auth for fj
* Handle trace properly even when using system

Signed-off-by: Phil Dibowitz <phil@ipom.com>
