### PR TITLE
Support hash-based checks so we can provide names for checks

### DIFF
--- a/examples/sample_repoconfig.yaml
+++ b/examples/sample_repoconfig.yaml
@@ -37,8 +37,11 @@ release_branches:
 # is assumed it is a relative path and `sj` will check that the file exists.
 
 lint:
+  # can be a string which is just a command to run...
   - scripts/run_rubocop.sh
-  - scripts/run_mdl.sh
+  # want it to have a pretty name? Entries can be a hash instead...
+  - name: mdl
+    command: scripts/run_mdl.sh
 
 # `unit` is a list of scripts to run when `sj unit` is executed (or, if
 # configured to run on `sj spush`/`sj fpush`- see `on_push` below).  Regardless
@@ -47,8 +50,11 @@ lint:
 # assumed it is a relative path and `sj` will check that the file exists.
 
 unit:
+  # like lint, supports bare strings...
   - bundle exec rspec
-  - scripts/run_tests.sh
+  # or hashes...
+  - name: unittests
+    command: scripts/run_tests.sh
 
 # `lint_list_cmd` is like `lint`, except it's a command to run which will
 # determine the proper lints to run and return them, one per line. This is

--- a/lib/sugarjar/commands/checks.rb
+++ b/lib/sugarjar/commands/checks.rb
@@ -48,7 +48,21 @@ class SugarJar
         )
         return false
       end
-      s.stdout.split("\n")
+      output = s.stdout
+      if output.start_with?("---\n")
+        begin
+          checks = YAML.safe_load(s.stdout)
+          return checks
+        rescue Psych::SyntaxError => e
+          SugarJar::Log.error(
+            "#{type}_list_cmd (#{cmd}) produced invalid YAML: #{e.message}",
+          )
+          return false
+        end
+      end
+
+      # otherwise it's one line per command
+      output.split("\n")
     end
 
     # determine if we're using the _list_cmd and if so run it to get the
@@ -81,15 +95,23 @@ class SugarJar
       repo_root = SugarJar::Git.repo_root
       Dir.chdir repo_root do
         checks = get_checks(type)
-        # if we failed to determine the checks, the the checks have effectively
+        # if we failed to determine the checks, then the checks have effectively
         # failed
         return false unless checks
 
         checks.each do |check|
-          SugarJar::Log.debug("Running #{type} #{check}")
+          if check.is_a?(Hash)
+            command = check['command']
+            name = check['name'] || command.split.first
+          else
+            command = check
+            name = check.split.first
+          end
+
+          SugarJar::Log.debug("Running #{type} #{name}: #{command}")
           skip_redo = false
 
-          short = check.split.first
+          short = command.split.first
           if short.include?('/')
             short = File.join(repo_root, short) unless short.start_with?('/')
             unless File.exist?(short)
@@ -99,12 +121,12 @@ class SugarJar
             SugarJar::Log.error("Configured #{type} #{short} does not exist!")
             return false
           end
-          s = Mixlib::ShellOut.new(check).run_command
+          s = Mixlib::ShellOut.new(command).run_command
 
           # Linters auto-correct, lets handle that gracefully
           if type == 'lint' && dirty?
             SugarJar::Log.info(
-              "[#{type}] #{short}: #{color('Corrected', :yellow)}",
+              "[#{type}] #{name}: #{color('Corrected', :yellow)}",
             )
             SugarJar::Log.warn(
               "The linter modified the repo. Here's the diff:\n",
@@ -142,14 +164,14 @@ class SugarJar
 
           if s.error?
             SugarJar::Log.info(
-              "[#{type}] #{short} #{color('failed', :red)}, output follows " +
+              "[#{type}] #{name} #{color('failed', :red)}, output follows " +
               "(see debug for more)\n#{s.stdout}",
             )
             SugarJar::Log.debug(s.format_for_exception)
             return false
           end
           SugarJar::Log.info(
-            "[#{type}] #{short}: #{color('OK', :green)}",
+            "[#{type}] #{name}: #{color('OK', :green)}",
           )
         end
       end

--- a/spec/commands/checks_spec.rb
+++ b/spec/commands/checks_spec.rb
@@ -9,33 +9,65 @@ describe 'SugarJar::Commands' do
       expect(sj.get_checks_from_command('unit')).to eq(nil)
     end
 
-    it 'runs the commands if they exist and returns the results' do
-      expect(SugarJar::RepoConfig).to receive(:config).and_return(
-        {
-          'lint_list_cmd' => 'get_lint_commands',
-          'unit_list_cmd' => 'get_unit_commands',
-        },
-      )
-      sj = SugarJar::Commands.new({ 'no_change' => true })
-      %w{lint unit}.each do |type|
-        cmd = "get_#{type}_commands"
-        expect(File).to receive(:exist?).with(cmd).and_return(true)
-        so = double(
-          {
-            :error? => false,
-            :stdout => "#{type}_one\n#{type}_two\n",
-          },
-        )
-        expect(Mixlib::ShellOut).to receive(:new).and_return(so)
-        expect(so).to receive(:run_command).and_return(so)
-        expect(sj.get_checks_from_command(type)).
-          to eq(["#{type}_one", "#{type}_two"])
+    context 'runs the commands if they exist and returns the results' do
+      %w{yaml bare}.each do |outtype|
+        it "with #{outtype} output" do
+          expect(SugarJar::RepoConfig).to receive(:config).and_return(
+            {
+              'lint_list_cmd' => 'get_lint_commands',
+              'unit_list_cmd' => 'get_unit_commands',
+            },
+          )
+          sj = SugarJar::Commands.new({ 'no_change' => true })
+          %w{lint unit}.each do |type|
+            checks = %w{one two}.map { |c| "#{type}_#{c}" }
+            case outtype
+            when 'yaml'
+              out = "---\n#{
+                checks.map do |c|
+                  "- name: #{c}\n  command: #{c}_script.sh"
+                end.join("\n")
+              }"
+            when 'bare'
+              out = checks.join("\n") + "\n"
+            end
+
+            cmd = "get_#{type}_commands"
+            expect(File).to receive(:exist?).with(cmd).and_return(true)
+            so = double(
+              {
+                :error? => false,
+                :stdout => out,
+              },
+            )
+            expect(Mixlib::ShellOut).to receive(:new).and_return(so)
+            expect(so).to receive(:run_command).and_return(so)
+            case outtype
+            when 'yaml'
+              expect(sj.get_checks_from_command(type)).to eq(
+                [
+                  {
+                    'name' => "#{type}_one",
+                    'command' => "#{type}_one_script.sh",
+                  },
+                  {
+                    'name' => "#{type}_two",
+                    'command' => "#{type}_two_script.sh",
+                  },
+                ],
+              )
+            when 'bare'
+              expect(sj.get_checks_from_command(type)).
+                to eq(["#{type}_one", "#{type}_two"])
+            end
+          end
+        end
       end
     end
   end
 
   context '#get_checks' do
-    it 'defaults to _command variety' do
+    it 'defaults to _cmd variety' do
       expect(SugarJar::RepoConfig).to receive(:config).and_return(
         {
           'lint_list_cmd' => 'get_lint_commands',
@@ -55,7 +87,7 @@ describe 'SugarJar::Commands' do
       end
     end
 
-    it 'returns false if _command does not exist' do
+    it 'returns false if _cmd does not exist' do
       expect(SugarJar::RepoConfig).to receive(:config).and_return(
         {
           'lint_list_cmd' => 'get_lint_commands',
@@ -72,7 +104,7 @@ describe 'SugarJar::Commands' do
       end
     end
 
-    it 'returns false if _command fails' do
+    it 'returns false if _cmd fails' do
       expect(SugarJar::RepoConfig).to receive(:config).and_return(
         {
           'lint_list_cmd' => 'get_lint_commands',
@@ -92,7 +124,7 @@ describe 'SugarJar::Commands' do
       end
     end
 
-    it 'uses static configs if no _command variety' do
+    it 'uses static configs if no _cmd variety' do
       expect(SugarJar::RepoConfig).to receive(:config).and_return(
         {
           'lint' => ['lint_foo'],
@@ -170,6 +202,26 @@ describe 'SugarJar::Commands' do
         expect(so).to receive(:run_command).and_return(so)
         expect(sj).to receive(:dirty?).and_return(false) if type == 'lint'
         expect(sj.run_check(type, true)).to eq(false)
+      end
+    end
+
+    it 'handles hash format checks' do
+      sj = SugarJar::Commands.new({ 'no_change' => true })
+      %w{lint unit}.each do |type|
+        name = "#{type}_foo"
+        cmd = "#{name}.sh"
+        expect(SugarJar::Git).to receive(:repo_root).and_return('root')
+        expect(Dir).to receive(:chdir).with('root').and_yield
+        expect(sj).to receive(:get_checks).with(type).
+          and_return([{ 'name' => name, 'command' => cmd }])
+        expect(SugarJar::Util).to receive(:which_nofail).with(cmd).
+          and_return("/some/path/#{cmd}")
+        so = double({ :stdout => 'some output', :error? => false })
+        expect(Mixlib::ShellOut).to receive(:new).
+          with(cmd).and_return(so)
+        expect(so).to receive(:run_command).and_return(so)
+        expect(sj).to receive(:dirty?).and_return(false) if type == 'lint'
+        sj.run_check(type, true)
       end
     end
   end

--- a/spec/commands_spec.rb
+++ b/spec/commands_spec.rb
@@ -103,7 +103,6 @@ describe 'SugarJar::Commands' do
     end
 
     it 'honors CLI overrides' do
-      SugarJar::Log.level = :debug
       # bypass the git repo we're running in or it will taint the @config
       expect(SugarJar::Git).to receive(:in_repo?).at_least(
         :once,


### PR DESCRIPTION
Currently the 'name' we print out for checks is the first word,
but often that ends up being 'bash' or 'python' or 'ruby', which
is very not helpful.

Allow checks in repoconfigs to be a hash with a 'name' and a 'command'.

Signed-off-by: Phil Dibowitz <phil@ipom.com>
