### PR TITLE
Add ruby 4.0, drop ruby 3.2

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Setup ruby
       uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
       with:
-        ruby-version: '3.2'
+        ruby-version: '3.4'
     - name: install deps
       run: bundle install
     - name: Run rubocop

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [3.2, 3.3, 3.4]
+        ruby: [3.3, 3.4, 4.0]
     runs-on: ubuntu-latest
     steps:
     - name: Harden the runner (Audit all outbound calls)

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 3.2
+  TargetRubyVersion: 3.3
   NewCops: enable
   Exclude:
     - 'rubygem-sugarjar.spec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,7 @@ PATH
     sugarjar (4.0.0)
       deep_merge
       diffy
+      logger
       mixlib-log
       mixlib-shellout
       pastel
@@ -29,6 +30,7 @@ GEM
       kramdown (~> 2.0)
     language_server-protocol (3.17.0.6)
     lint_roller (1.1.0)
+    logger (1.7.0)
     mdl (0.18.0)
       kramdown (~> 2.5)
       kramdown-parser-gfm (~> 1.1)

--- a/sugarjar.gemspec
+++ b/sugarjar.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
   spec.email = ['phil@ipom.com']
   spec.license = 'Apache-2.0'
   spec.homepage = 'https://github.com/jaymzh/sugarjar'
-  spec.required_ruby_version = '>= 3.2'
+  spec.required_ruby_version = '>= 3.3'
   docs = %w{
     README.md
     LICENSE
@@ -27,6 +27,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'deep_merge'
   spec.add_dependency 'diffy'
+  spec.add_dependency 'logger'
   spec.add_dependency 'mixlib-log'
   spec.add_dependency 'mixlib-shellout'
   spec.add_dependency 'pastel'


### PR DESCRIPTION
3.2 is EOL.
4.0 is stable.

Signed-off-by: Phil Dibowitz <phil@ipom.com>
